### PR TITLE
Clearly described the usage of FeePayerManager with explicit chain ID…

### DIFF
--- a/docs/bapp/sdk/caver-java/getting-started.md
+++ b/docs/bapp/sdk/caver-java/getting-started.md
@@ -338,7 +338,9 @@ After the fee payer gets the transaction from the sender, the fee payer can send
 
 ```java
 KlayCredentials feePayer = KlayWalletUtils.loadCredentials(<password>, <walletfilePath>);
-FeePayerManager feePayerManager = new FeePayerManager.Builder(caver, feePayer).build();
+FeePayerManager feePayerManager = new FeePayerManager.Builder(caver, feePayer)
+        .setChainId(ChainId.BAOBAB_TESTNET)
+        .build();
 feePayerManager.executeTransaction(senderRawTransaction);
 ```
 


### PR DESCRIPTION
… configuration. The old version does not correctly indicate the need for setting chain ID, which is required when using different networks other than Baobab. 