### PR TITLE
update samples to recent solidity version

### DIFF
--- a/docs/bapp/tutorials/count-bapp/4.-write-smart-contract.md
+++ b/docs/bapp/tutorials/count-bapp/4.-write-smart-contract.md
@@ -9,16 +9,16 @@ b. Users can increase `count` variable by 1 or decrease it by 1. So there would 
 
 ## 2\) Define the variable
 
-Before setting a variable, we should specify the solidity version. Let's use 0.4.24 stable version.
+Before setting a variable, we should specify the solidity version. Let's use 0.5.6 stable version.
 
 ```text
-pragma solidity 0.4.24; // Specify solidity's version
+ solidity 0.5.6; // Specify solidity's version
 ```
 
 Then we will name our contract "Count".
 
 ```text
-pragma solidity 0.4.24;
+pragma solidity 0.5.6;
 
 contract Count { // set contract names to "Count"
 
@@ -28,7 +28,7 @@ contract Count { // set contract names to "Count"
 We need to declare the variable `count` as `uint`\(unsigned integer\) type, and initialize it to be 0.
 
 ```text
-pragma solidity 0.4.24;
+pragma solidity 0.5.6;
 
 contract Count {
   uint public count = 0; // Declare count variable as uint type and intialize its value to 0.
@@ -42,7 +42,7 @@ We need two functions, `plus` and `minus`. Each function's role is:
 `minus` - decrease the `count` by 1. \(count = count - 1\)
 
 ```text
-pragma solidity 0.4.24;
+pragma solidity 0.5.6;
 
 contract Count {
   uint public count = 0;
@@ -74,7 +74,7 @@ So we will have a variable, `lastParticipant` as `address` type:
 `address public lastParticipant;`
 
 ```text
-pragma solidity 0.4.24;
+pragma solidity 0.5.6;
 
 contract Count {
   uint public count = 0;
@@ -95,7 +95,7 @@ contract Count {
 To track the last participant's address, we store the address to `lastParticipant` like the below:
 
 ```text
-pragma solidity 0.4.24;
+pragma solidity 0.5.6;
 
 contract Count {
   uint public count = 0;

--- a/docs/bapp/tutorials/klaystagram/4.-write-klaystagram-smart-contract.md
+++ b/docs/bapp/tutorials/klaystagram/4.-write-klaystagram-smart-contract.md
@@ -18,13 +18,13 @@ We will make a simple contract called "Klaystagram".
 
 ## 2\) Contract setup
 
-* Specify solidity version. We recommend using 0.4.24 stable version.
+* Specify solidity version. We recommend using 0.5.6 stable version.
 * We will make use of ERC721 standard to build non-fungible tokens.  
   * Import `ERC721.sol` and `ERC721Enumerable.sol`
   * Check out detailed information about ERC721 at [erc721.org](http://erc721.org)
 
 ```text
-pragma solidity 0.4.24;
+pragma solidity 0.5.6;
 
 import "./ERC721/ERC721.sol";
 import "./ERC721/ERC721Enumerable.sol";
@@ -67,7 +67,7 @@ Let's write some functions that interact with the contract. In this tutorial let
 Finally, initialize `PhotoData` struct, locate it inside `_photoList` mapping, and push the owner address into `ownerHistory` array. And don't forget to emit the event we just created. As mentioned above, this event will be included in transaction receipt.
 
 ```text
-function uploadPhoto(bytes photo, string title, string location, string description) public {
+function uploadPhoto(bytes memory photo, string memory title, string memory location, string memory description) public {
     uint256 tokenId = totalSupply() + 1;
 
     _mint(msg.sender, tokenId);
@@ -122,15 +122,15 @@ function transferFrom(address from, address to, uint256 tokenId) public {
 Finally, let's make a getter function that fetchs data stored in the smart contract. By calling a single function, we want to fetch every information regarding a specific photo. So `getPhoto` function takes an index\(token id\) as an argument and returns every element in PhotoData struct.
 
 ```text
-function getPhoto(uint tokenId) public view 
-returns(uint256, address[], bytes, string, string, string, uint256) {
-    require(_photoList[tokenId].tokenId != 0);
+function getPhoto(uint tokenId) public view
+returns(uint256, address[] memory, bytes memory, string memory, string memory, string memory, uint256) {
+    require(_photoList[tokenId].tokenId != 0, "Photo does not exist");
     return (
-        _photoList[tokenId].tokenId, 
-        _photoList[tokenId].ownerHistory, 
-        _photoList[tokenId].photo, 
-        _photoList[tokenId].title, 
-        _photoList[tokenId].location, 
+        _photoList[tokenId].tokenId,
+        _photoList[tokenId].ownerHistory,
+        _photoList[tokenId].photo,
+        _photoList[tokenId].title,
+        _photoList[tokenId].location,
         _photoList[tokenId].description,
         _photoList[tokenId].timestamp);
 }

--- a/docs/bapp/tutorials/klaystagram/5.-deploy-contract.md
+++ b/docs/bapp/tutorials/klaystagram/5.-deploy-contract.md
@@ -47,10 +47,10 @@ module.exports = {
     },
   },
 
-  // Specify the version of compiler, we use 0.4.24
+  // Specify the version of compiler, we use 0.5.6
   compilers: {
     solc: {
-      version: '0.4.24',
+      version: '0.5.6',
     },
   },
 }
@@ -68,7 +68,7 @@ See `networks` property above. `klaytn` network has 4 properties,
 
 ### `compiler` property
 
-Remember that for Solidity contract we used version 0.4.24, thus specify compiler version here.
+Remember that for Solidity contract we used version 0.5.6, thus specify compiler version here.
 
 ## 3\) Deployment setup
 

--- a/docs/getting-started/quick-start/deploy-a-smart-contract.md
+++ b/docs/getting-started/quick-start/deploy-a-smart-contract.md
@@ -32,25 +32,25 @@ $ vi KlaytnGreeter.sol
 Write the following code in KlaytnGreeter.sol.
 
 ```text
-pragma solidity 0.4.24;
+pragma solidity 0.5.6;
 contract Mortal {
     /* Define variable owner of the type address */
-    address owner;
+    address payable owner;
     /* This function is executed at initialization and sets the owner of the contract */
-    function Mortal() { owner = msg.sender; }
+    constructor () public { owner = msg.sender; }
     /* Function to recover the funds on the contract */
-    function kill() { if (msg.sender == owner) selfdestruct(owner); }
+    function kill() public payable { if (msg.sender == owner) selfdestruct(owner); }
 }
 
 contract KlaytnGreeter is Mortal {
     /* Define variable greeting of the type string */
     string greeting;
     /* This runs when the contract is executed */
-    function KlaytnGreeter(string _greeting) public {
+    constructor (string memory _greeting) public {
         greeting = _greeting;
     }
     /* Main function */
-    function greet() constant returns (string) {
+    function greet() public view returns (string memory) {
         return greeting;
     }
 }
@@ -103,7 +103,7 @@ module.exports = {
     },
     compilers: {
       solc: {
-        version: "0.4.24"    // Specify compiler's version to 0.4.24
+        version: "0.5.6"    // Specify compiler's version to 0.5.6
       }
   }
 };

--- a/docs/getting-started/quick-start/install-development-tools.md
+++ b/docs/getting-started/quick-start/install-development-tools.md
@@ -60,7 +60,7 @@ We can install Truffle either
 ```bash
 $ sudo npm install -g truffle@4.1.15
 $ cd /usr/local/lib/node_modules/truffle
-$ sudo npm install solc@0.4.24
+$ sudo npm install solc@0.5.6
 $ cd -
 ```
 
@@ -72,7 +72,7 @@ or
 # Assuming you are in $HOME/klaytn/.
 $ npm install truffle@4.1.15
 $ cd node_modules/truffle
-$ npm install solc@0.4.24
+$ npm install solc@0.5.6
 $ cd -
 $ ln -s node_modules/truffle/build/cli.bundled.js truffle
 $ export PATH=`pwd`:$PATH

--- a/docs/klaytn/design/computation/execution-model.md
+++ b/docs/klaytn/design/computation/execution-model.md
@@ -74,7 +74,7 @@ A function of a smart contract can be called and executed either by sending a tr
 
 ### Disabling Smart Contracts
 
-Because smart contracts exist in the Klaytn blockchain, they cannot be deleted; they can only be disabled. For now, Klaytn has adopted the same process for disabling a Klaytn smart contract as is used for disabling smart contracts in Ethereum. For example, the Klaytn smart contract for KLVM can be disabled by using the [`selfdestruct(address recipient)`](https://solidity.readthedocs.io/en/v0.4.24/introduction-to-smart-contracts.html#self-destruct) call in Solidity \(or the KLVM opcode `SELFDESTRUCT`\). The Klaytn team will also provide ways to disable smart contracts for other execution environments.
+Because smart contracts exist in the Klaytn blockchain, they cannot be deleted; they can only be disabled. For now, Klaytn has adopted the same process for disabling a Klaytn smart contract as is used for disabling smart contracts in Ethereum. For example, the Klaytn smart contract for KLVM can be disabled by using the [`selfdestruct(address recipient)`](https://solidity.readthedocs.io/en/v0.5.6/introduction-to-smart-contracts.html#self-destruct) call in Solidity \(or the KLVM opcode `SELFDESTRUCT`\). The Klaytn team will also provide ways to disable smart contracts for other execution environments.
 
 ### Upgrading Smart Contracts
 

--- a/docs/smart-contract/sample-contracts/erc-20/1-erc20.md
+++ b/docs/smart-contract/sample-contracts/erc-20/1-erc20.md
@@ -5,7 +5,7 @@
 The complete source code of `MyERC20.sol` is given below. In this implementation, `constructor` invokes `_mint` to mint a predefined amount of token on contract deploy.
 
 ```text
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP. Does not include
@@ -353,8 +353,8 @@ contract MyERC20 is IERC20 {
     function _burn(address account, uint256 value) internal {
         require(account != address(0), "ERC20: burn from the zero address");
 
+	_balances[account] = _balances[account].sub(value);
         _totalSupply = _totalSupply.sub(value);
-        _balances[account] = _balances[account].sub(value);
         emit Transfer(account, address(0), value);
     }
 

--- a/docs/smart-contract/sample-contracts/erc-20/2-erc20.md
+++ b/docs/smart-contract/sample-contracts/erc-20/2-erc20.md
@@ -10,11 +10,11 @@ You can use Klaytn IDE or use truffle to deploy `MyERC20` smart contract.
   * Get some test KLAY from the faucet - [https://baobab.wallet.klaytn.com/faucet](https://baobab.wallet.klaytn.com/faucet)
 * Let's deploy `MyERC20.sol` with the deploy parameters of `BAOBABTOKEN`, `BAO` and `8`.
 
-![ERC20-1-deploy](images/erc20-1-deploy.png)
+![ERC20-1-deploy](./images/erc20-1-deploy.png)
 
 After deploying, you can invoke `balnaceOf` with your account which was used to deploy the contract. You will find there are `10000000000000` tokens available in your account as below. Because you gave `decimal` to be `8` when deploying the contract above, it minted the fixed number of `100000` tokens in the constructor and one token has the decimal value of `10^8`. `totalSupply` method will return the total supply of tokens minted which should be also `10000000000000`.
 
-![ERC20-2-owner-token](images/erc20-2-owner_token.png)
+![ERC20-2-owner-token](./images/erc20-2-owner_token.png)
 
 Now `MyERC20` is live !
 
@@ -83,7 +83,7 @@ module.exports = {
     },
     compilers: {
       solc: {
-        version: "0.4.24"    // Specify compiler's version to 0.4.24
+        version: "0.5.6"    // Specify compiler's version to 0.5.6
       }
   }
 };

--- a/docs/smart-contract/sample-contracts/erc-20/3-erc20.md
+++ b/docs/smart-contract/sample-contracts/erc-20/3-erc20.md
@@ -4,9 +4,9 @@ You can use [Baobab Klaytn Wallet](https://baobab.wallet.klaytn.com) to query yo
 
 You can add ERC-20 compatible token in your wallet with the address of the deployed `MyERC20` contract as below.
 
-![ERC20-3-Add\_token](images/erc20-3-add_token.png)
+![ERC20-3-Add\_token](./images/erc20-3-add_token.png)
 
 After adding the ERC-20 token in the wallet app, the balance of your `BAOBABTOKEN` will be shown in addition to the balance of KLAY as below. You can see there is `100000` `BAO` tokens in the account.
 
-![ERC20-4-wallet-token](images/erc20-4-wallet-token.png)
+![ERC20-4-wallet-token](./images/erc20-4-wallet-token.png)
 

--- a/docs/smart-contract/sample-contracts/erc-721/1-erc721.md
+++ b/docs/smart-contract/sample-contracts/erc-721/1-erc721.md
@@ -5,7 +5,7 @@
 The complete source code of `MyERC721Card.sol` is given below.
 
 ```text
-pragma solidity ^0.4.24;
+pragma solidity ^0.5.0;
 
 // https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v2.3.0/contracts/utils/Address.sol
 /**
@@ -623,7 +623,7 @@ contract MyERC721Card is ERC721{
         owner = msg.sender; // owner of MyERC721Card contract who can create a new card
     }
 
-    function mintCard(string name, address account) public {
+    function mintCard(string memory name, address account) public {
         require(owner == msg.sender); // Only the Owner can create Items
         uint256 cardId = cards.length; // Unique card ID
         cards.push(Card(name, 1));

--- a/docs/smart-contract/sample-contracts/erc-721/2-erc721.md
+++ b/docs/smart-contract/sample-contracts/erc-721/2-erc721.md
@@ -10,17 +10,17 @@ You can use Klaytn IDE or use truffle to deploy above `MyERC721Card` smart contr
   * Get some test KLAY from the faucet - [https://baobab.wallet.klaytn.com/faucet](https://baobab.wallet.klaytn.com/faucet)
 * Let's deploy `MyERC721Card.sol` as below.
 
-![ERC721-1-deploy](images/erc721-1-deploy.png)
+![ERC721-1-deploy](./images/erc721-1-deploy.png)
 
 Now `MyERC721Card` is live! You can mint and transfer cards which are ERC-721 compatible non-fungible tokens.
 
 Let's mint two cards, i.e. `King` and `Queen` cards, for account `0x2645BA5Be42FfEe907ca8e9d88f6Ee6dAd8c1410` as below.
 
-![ERC721-2-mint-king](images/erc721-2-mint-king.png) ![ERC721-3-mint-queen](images/erc721-3-mint-queen.png)
+![ERC721-2-mint-king](./images/erc721-2-mint-king.png) ![ERC721-3-mint-queen](./images/erc721-3-mint-queen.png)
 
 Now we have minted two cards and let's check the status of these `MyERC721Card` non-fungible token.
 
-![ERC721-4-cards-status](images/erc721-4-cards-status.png)
+![ERC721-4-cards-status](./images/erc721-4-cards-status.png)
 
 * `balanceOf` shows that account `0x2645BA5Be42FfEe907ca8e9d88f6Ee6dAd8c1410` has two cards.
 * `cards` with parameter `1` shows that `MyERC721Card` with token ID `1` is a `Queen` of level 1.
@@ -103,7 +103,7 @@ module.exports = {
     },
     compilers: {
       solc: {
-        version: "0.4.24"    // Specify compiler's version to 0.4.24
+        version: "0.5.6"    // Specify compiler's version to 0.5.6
       }
   }
 };

--- a/docs/smart-contract/sample-contracts/klaytngreeter.md
+++ b/docs/smart-contract/sample-contracts/klaytngreeter.md
@@ -5,25 +5,25 @@
 ## Writing KlaytnGreeter
 
 ```text
-pragma solidity 0.4.24;
+pragma solidity 0.5.6;
 contract Mortal {
     /* Define variable owner of the type address */
-    address owner;
+    address payable owner;
     /* This function is executed at initialization and sets the owner of the contract */
-    function Mortal() { owner = msg.sender; }
+    constructor () public { owner = msg.sender; }
     /* Function to recover the funds on the contract */
-    function kill() { if (msg.sender == owner) selfdestruct(owner); }
+    function kill() public { if (msg.sender == owner) selfdestruct(owner); }
 }
 
 contract KlaytnGreeter is Mortal {
     /* Define variable greeting of the type string */
     string greeting;
     /* This runs once when the contract is created */
-    function KlaytnGreeter(string _greeting) public {
+    constructor (string memory _greeting) public {
         greeting = _greeting;
     }
     /* Main function */
-    function greet() constant returns (string) {
+    function greet() public view returns (string memory) {
         return greeting;
     }
 }

--- a/docs/smart-contract/solidity-smart-contract-language.md
+++ b/docs/smart-contract/solidity-smart-contract-language.md
@@ -30,7 +30,7 @@ Other materials that are useful for getting started with Solidity include the fo
 This section presents an example of Solidity source code to provide readers with an idea of how smart contracts look and how to write a contract. Note that the code included here is provided solely for explanatory purposes; it is not intended for production purposes. In the code, `(require)` means that the line is required for any Solidity source file while `(optional)` indicates that the line is not always needed. The symbol `Ln:` is not part of the Solidity code and is included here only to show the line numbers. Please do not include these symbols in source code intended for real use.
 
 ```text
-L01: pragma solidity 0.4.24;   // (required) version pragma
+L01: pragma solidity 0.5.6;   // (required) version pragma
 L02:
 L03: import "filename";        // (optional) imporiting other source files
 L04:


### PR DESCRIPTION
https://app.gitbook.com/@klaytn/s/wip-newdoc/v/gitbook-update-solidity-version/bapp/tutorials/count-bapp/4.-write-smart-contract 
1. update samples to recent solidity version
before: 0.4.24
after: 0.5.6 and 0.5.0(ERC20/ERC721)
2. md파일 내에서 참조하는 이미지의 잘못된 경로 수정