### PR TITLE
Applied modification of signTransaction

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.klay.accounts.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.klay.accounts.md
@@ -145,7 +145,7 @@ Signs a Klaytn transaction with a given private key.
 
 **Return Value**
 
-`Promise` returning `Object`: The signed transaction data RLP encoded values as follows:
+`Promise` returning `Object`: The RLP encoded signed transaction. The object properties are as follows:
 
 | Name | Type | Description |
 | --- | --- | --- |


### PR DESCRIPTION
This PR introduces applying modification of caver.klay.accounts.signTransaction

This modification is available since caver-js v.1.20-rc.3

The main changes are below:

1. private key parameter : private key can be optional. and also private key can be an array type. when private key is optional, caver-js will find account from caver.klay.accounts.wallet and use that account for signing. and if private key is array, signTransaction will sign with all private key in array.

2. signatures, feePayerSignatures properties: when sender sign to transaction, the signature array will be returned with 'signatures'. when fee payer sign to transaction, the signature array will be returned with 'feePayerSignatures'