### PR TITLE
add klay exchange

### DIFF
--- a/docs/getting-started/getting-klay.md
+++ b/docs/getting-started/getting-klay.md
@@ -9,7 +9,8 @@ The **testnet KLAY** faucet runs on the Baobab network. The faucet can be access
 
 ### KLAY Exchange List
 
-TBA
+Below is the inclusive but not exhaustive list of major KLAY exchanges.
 
+- [Upbit Indonesia](https://id.upbit.com/exchange?code=CRIX.UPBIT.IDR-KLAY)
 
 


### PR DESCRIPTION
https://app.gitbook.com/@klaytn/s/docs-dev/v/gitbook-klayexchange/getting-started/getting-klay

개발하려면 KLAY 가 필요한데 얻을 방법이 없었으니
KLAY exchange 가 흔해지기 전까지는 목록을 유지하는 것이 어떨까 하는데, 혹시 부적절하면 알려주세요. 
