### PR TITLE
Add note for not exist in network

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.klay/account.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.klay/account.md
@@ -144,7 +144,7 @@ caver.klay.getAccountKey(address [, defaultBlock] [, callback])
 
 Returns the account key of the Externally Owned Account (EOA) of the given address. If the account has AccountKeyLegacy or the account of the given address is a Smart Contract Account, it will return an empty key value. See [Account Key](../../../../../klaytn/design/accounts.md#account-key).
 
-**NOTE** getAccountKey returns the account key that exists on the network, so even if a key pair is created, null is returned if the account matching the address does not exist on the actual blockchain network.
+**NOTE** getAccountKey returns the account key if the account exists on the network, so even if a key pair is created, null is returned if the account matching the address does not exist on the actual blockchain network.
 
 **Parameters**
 


### PR DESCRIPTION
This PR introduces adding NOTE for accountCreated, getAccount and getAccountKey.

This note is about situation when user made key pair, but not exist in network.

refer https://groundx.atlassian.net/browse/KASQ-7#icft=KASQ-7