### PR TITLE
Run readability tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   check_link:
     docker:
@@ -8,9 +8,14 @@ jobs:
       - checkout
       - run: ~/go/bin/liche -r ~/klaytn-docs -x "^http.*" --document-root ~/klaytn-docs/docs
 
-
 workflows:
   version: 2
-  job_check_link:
+  check_docs:
     jobs:
       - check_link
+      - readability/check-readability:
+          pr-only-changed: true
+          check-regular-commits: false
+
+orbs:
+  readability: ground-x/readability@0.1.0


### PR DESCRIPTION
This adds readability testing for files modified in PRs.

For example output, please see: https://circleci.com/gh/ground-x/klaytn-docs/2065

Key points are:
* It only runs on PRs, and only for modified files -- If needed we can run on all files, but it takes a very long time and shows many unrelated warnings. In that case, it would be best to run once a day instead.
* Readability issues are treated as warnings and not errors, so they don't prevent merging.
* Warnings are shown for the whole file, not just modified lines. I think trying to determine which lines changed would be very difficult and error prone, but I can revisit this if needed.