### PR TITLE
Run readability tests for same-repo PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,4 +18,4 @@ workflows:
           check-regular-commits: false
 
 orbs:
-  readability: ground-x/readability@0.1.0
+  readability: ground-x/readability@0.2.1


### PR DESCRIPTION
Resolves the issue where readability tests did not run for PRs where the source and destination branch are in the same repo.

CircleCI handles forked PRs and same-repo PRs a bit differently. `ground-x/readability@0.2.1` adds support for both cases, so updating should fix the issue.