### PR TITLE
Added feePayerSignTransaction and modified signTransaction

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.klay.accounts.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.klay.accounts.md
@@ -818,7 +818,8 @@ caver.klay.accounts.signTransaction(tx [, privateKey] [, callback])
 
 Signs a Klaytn transaction with a given private key.
 
-Since caver-js [v1.2.0](https://www.npmjs.com/package/caver-js/v/1.2.0) sender can sign a transaction with the transaction object or RLP encoded transaction (rawTransaction) as a parameter. But fee payer can sign a transaction with only a fee payer transaction format (object defines sendRawTransaction and feePayer) with signTransaction function. If you want to sign a transaction with transaction object or RLP encoded transaction as a fee payer, then use [caver.klay.accounts.feePayerSignTransaction](#feepayersigntransaction).
+Since caver-js [v1.2.0](https://www.npmjs.com/package/caver-js/v/1.2.0), this method takes an RLP-encoded transaction as an input as well as a plain transaction object. See [caver.klay.sendTransaction](./caver.klay/transaction.md#sendtransaction) for the various types of transaction object. This method basically signs as a sender. 
+If you want to sign as a fee-payer, we recommend to use [caver.klay.accounts.feePayerSignTransaction](#feepayersigntransaction). But, fee-payers can still sign using this method by passing an object, `{senderRawTransction: rawTransaction, feePayer: feePayerAddress}`, as `tx`. senderRawTransaction must be a FEE_DELEGATED_ type transaction.
 
 Also since caver-js [v1.2.0](https://www.npmjs.com/package/caver-js/v/1.2.0), signTransaction keeps the existing signatures/feePayerSignatures in the input transaction and appends the signature(s) of the signer to it.
 
@@ -1014,7 +1015,7 @@ caver.klay.accounts.feePayerSignTransaction(tx, feePayerAddress [, privateKey] [
 
 Signs a transaction as a fee payer.
 
-Fee payers can sign a transaction with the transaction object or RLP encoded transaction (rawTransaction) as a parameter, without having to create a fee payer transaction format (object defines sendRawTransaction and feePayer).
+Fee payers can sign on a FEE_DELEGATED_ transaction. A transaction object or an RLP-encoded transaction can be passed as an argument.
 
 If privateKay is not given, feePayerKey of the fee payer's account inside the caver-js in-memory wallet is used.
 


### PR DESCRIPTION
This PR introduces new function named caver.klay.accounts.feePayerSignTransaction.

And also appliance new feature of caver.klay.accounts.signTransaction

gitbook link : https://app.gitbook.com/@klaytn/s/docs-dev/v/gitbook_feePayerSignTransaction/