### PR TITLE
Added caver.klay.accounts.wallet.updateAccountKey

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.klay.accounts.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.klay.accounts.md
@@ -1206,7 +1206,8 @@ Update the account's private key information stored in the wallet.
 
 **NOTE**: This function only changes the information stored in the wallet of caver-js. This function has no effect on the key information stored on the Klaytn network. Keys in the Klaytn network can be changed by sending a ['ACCOUNT_UPDATE'](./caver.klay/sendtx_account_update.md#sendtransaction-account_update) transaction.
 
-**NOTE** Since caver-js [v1.2.0](https://www.npmjs.com/package/caver-js/v/1.2.0) supports new AccountKeys (AccountKeyPublic, AccountKeyMultiSig, AccountKeyRoleBased), updatePrivateKey only works if the account's accountKey is AccountKeyPublic. If accountKey is AccountKeyPublic, the privateKey is updated by updating it to another AccountKeyPublic instance with a new private key string. The privateKey only represents the default key of the accountKey of the account, so it is recommended to use [caver.utils.updateAccountKey](#wallet-updateaccountkey) to update the accountKey.
+**NOTE** `updatePrivateKey` only works if the account's accountKey is AccountKeyPublic. 
+Since caver-js [v1.2.0](https://www.npmjs.com/package/caver-js/v/1.2.0) supports AccountKeys (AccountKeyPublic, AccountKeyMultiSig, AccountKeyRoleBased), `privateKey` becomes a read-only property referencing the defaultKey of the accountKey. This method does not directly update the `privateKey`, instead update the accountKey. This method is maintained for backward-compatibility. It is now recommended to use more generic [caver.utils.updateAccountKey](#wallet-updateaccountkey).
 
 **Parameters**
 


### PR DESCRIPTION
This PR introduces new functions named caver.klay.accounts.wallet.updateAccountKey.

This function will update accountKey of account.

gitbook link : https://app.gitbook.com/@klaytn/s/docs-dev/v/gitbook_updateAccountKey/