### PR TITLE
introduse rolebased, multisig account key

### DIFF
--- a/docs/bapp/sdk/caver-java/getting-started.md
+++ b/docs/bapp/sdk/caver-java/getting-started.md
@@ -384,7 +384,7 @@ caver-java introduces new classes to support the various types of [AccountKey](h
 
 ### AccountKey  <a id="account-key"></a>
 
-To update the account key on the Klaytn platform, caver-java provides the `AccountKey` Interface. The following describes `AccountKey` implementations, `AccountKeyPublic`, `AccountKeyWeightedMultiSig`, and `AccountKeyRolebased`.
+To update the account key on the Klaytn platform, caver-java provides the `AccountKey` interface. The following describes `AccountKey` implementations, `AccountKeyPublic`, `AccountKeyWeightedMultiSig`, and `AccountKeyRoleBased`.
 See [Account Update](#accountupdate) for how to update an Account.
 
 ### AccountKeyPublic <a id="account-key-public"></a>


### PR DESCRIPTION
This PR is intended to update the getting started documentation for the added features to support `WeghtedMultiSigAccountKey` and `RoleBasedAccountKey`.