### PR TITLE
Exclude SUMMARY.md and markdown headers from readability test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
       - readability/check-readability:
           pr-only-changed: true
           check-regular-commits: false
+          path-exclude-regex: SUMMARY.md
 
 orbs:
-  readability: ground-x/readability@0.3.0
+  readability: ground-x/readability@0.4.0


### PR DESCRIPTION
Update readability orb to v0.4.0 [(details)](https://circleci.com/orbs/registry/orb/ground-x/readability).

This version:
* fixes the issue where markdown `# headers` weren't stripped before processing.
* adds a `path-exclude-regex` option for excluding specific files.

Jira: https://groundx.atlassian.net/browse/GD-385
Test CI Job: https://circleci.com/gh/ground-x/klaytn-docs/4757