### PR TITLE
edit getModifiedAccounts to have an optional parameter

### DIFF
--- a/docs/bapp/json-rpc/api-references/debug/blockchain.md
+++ b/docs/bapp/json-rpc/api-references/debug/blockchain.md
@@ -168,7 +168,7 @@ code hash, or storage hash.
 | Name | Type | Description |
 | --- | --- | --- |
 | startBlockNum | int | The first block number of the range to check. |
-| endBlockNum | int | (optional)End block number for the range. |
+| endBlockNum | int | (optional) The last block number of the range. |
 
 **Return Value**
 


### PR DESCRIPTION
debug_getModifiedAccountsByHash/Number are apis which return changed accounts between given block range.
Also, the api can be used with only one parameter.
If a parameter is given, it compares the chosen block with the previous block and returns changed accounts