### PR TITLE
Documentation for KIP-17(non fungible token) in caver

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.klay.KIP17.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.klay.KIP17.md
@@ -5,7 +5,7 @@ description: >-
 
 # caver.klay.KIP17 <a id="caver-klay-kip17"></a>
 
-The `caver.klay.KIP17`, a javascript object, makes it easy to interact with a smart contract that implements [KIP-17](https://klaytn.github.io/kips/KIPs/kip-17-non_fungible_token) on the Klaytn blockchain. 
+The `caver.klay.KIP17`, a javascript object, makes it easy to interact with a smart contract that implements [KIP-17](http://kips.klaytn.com/KIPs/kip-17-non_fungible_token) on the Klaytn blockchain. 
 
 The `caver.klay.KIP17` inherits [caver.klay.Contract](caver.klay.Contract.md) and is implemented for KIP-17 token contracts. This section describes only the additional implementations of the caver.klay.KIP17 for easy to use.
 


### PR DESCRIPTION
This PR introduces documentation of non fungible token in caver-js.

The name of KIP17 can be modified after KIP is created.

gitbook link: https://app.gitbook.com/@klaytn/s/docs-dev/v/gitbook_kip8/