### PR TITLE
Update caver.klay.accounts.md

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.klay.accounts.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.klay.accounts.md
@@ -1904,7 +1904,7 @@ Encrypts an account to the Klaytn keystore v3 standard.
 
 **NOTE**: There are two ways to encrypt the private key when an account has a decoupled private key from the address.
 1. Use the [KlaytnWalletKey](../../../../klaytn/design/accounts.md#klaytn-wallet-key-format) as `encryptTarget` parameter.
-2. Use the address as `options` parameter to send the address as one of the parameters. See the third example below for usage of `options`.
+2. Use the address as `options.address` parameter to send the address as one of the parameters. See the third example below for the usage.
 
 **Return Value**
 


### PR DESCRIPTION
업데이트 내용은 아래와 같습니다:

1. ETR(English Text Review)
2. encryptV3 부분의 Note 내용을 다음과 같이 이해하고 영문 수정했습니다.

- decoupled 개인키를 사용할 때 개인키를 암호화하는 방법은 아래의 2가지가 있다:
(1) KlaytnWalletKey를 encryptTarget 파라미터로 써서 호출
(2) 주소(address)를 options 파라미터로 써서 호출. 단 주소를 옵션 파라미터에 넣는 방식은 밑에 3번째 예시를 참조할 것.

제가 이해한 것이 맞다면, 제가 커밋한 내용대로 하는 것이 더 명확한 것 같습니다.
