### PR TITLE
Updated caver-js version for KIP17

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.klay.KIP17.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.klay.KIP17.md
@@ -13,7 +13,7 @@ The code that implements KIP-17 for caver-js is available on the [caver-js Githu
 
 For more information about KIP-17, see [Klaytn Improvement Proposals](https://kips.klaytn.com/KIPs/kip-17).
 
-**NOTE** `caver.klay.KIP17` is supported since caver-js [v1.4.0](https://www.npmjs.com/package/caver-js/v/1.4.0).
+**NOTE** `caver.klay.KIP17` is supported since caver-js [v1.4.1](https://www.npmjs.com/package/caver-js/v/1.4.1).
 
 ## caver.klay.KIP17.deploy <a id="caver-klay-kip17-deploy"></a>
 


### PR DESCRIPTION
KIP17이 caver-js v1.4.1부터 지원되므로 버전을 변경했습니다.