### PR TITLE
Update Yum repo setup command use HTTPs URL

### DIFF
--- a/docs/node/core-cell/installation-guide/consensus-node-setup/installation-guide.md
+++ b/docs/node/core-cell/installation-guide/consensus-node-setup/installation-guide.md
@@ -1,6 +1,6 @@
 # Installation Guide <a id="installation-guide"></a>
 
-You can download the latest version of the `kcn`  on [Download](../download.md) page. 
+You can download the latest version of the `kcn`  on [Download](../download.md) page.
 
 ## Linux Archive Distribution <a id="linux-archive-distribution"></a>
 
@@ -65,7 +65,7 @@ $ yum install kcnd-baobab-vX.X.X.el7.x86_64.rpm
 Alternatively, you can install `kcnd` from the Klaytn Yum repo, run:
 
 ```bash
-$ sudo curl -o /etc/yum.repos.d/klaytn.repo http://packages.klaytn.net/config/rhel/7/prod.repo && sudo yum install kcnd
+$ sudo curl -o /etc/yum.repos.d/klaytn.repo https://packages.klaytn.net/config/rhel/7/prod.repo && sudo yum install kcnd
 ```
 
 ### Installed Location <a id="installed-location"></a>

--- a/docs/node/core-cell/installation-guide/proxy-node-setup/installation-guide.md
+++ b/docs/node/core-cell/installation-guide/proxy-node-setup/installation-guide.md
@@ -1,6 +1,6 @@
 # Installation Guide <a id="installation-guide"></a>
 
-You can download the latest version of the `kpn`  on [Download](../download.md) page. 
+You can download the latest version of the `kpn`  on [Download](../download.md) page.
 
 ## Linux Archive Distribution <a id="linux-archive-distribution"></a>
 
@@ -65,7 +65,7 @@ $ yum install kpnd-baobab-vX.X.X.el7.x86_64.rpm
 Alternatively, you can install `kpnd` from the Klaytn Yum repo, run:
 
 ```bash
-$ sudo curl -o /etc/yum.repos.d/klaytn.repo http://packages.klaytn.net/config/rhel/7/prod.repo && sudo yum install kpnd
+$ sudo curl -o /etc/yum.repos.d/klaytn.repo https://packages.klaytn.net/config/rhel/7/prod.repo && sudo yum install kpnd
 ```
 
 ### Installed Location <a id="installed-location"></a>

--- a/docs/node/endpoint-node/installation-guide/installation-guide.md
+++ b/docs/node/endpoint-node/installation-guide/installation-guide.md
@@ -1,6 +1,6 @@
 # Installation Guide <a id="installation-guide"></a>
 
-You can download the latest version of the `ken` on [Download](download.md) page. 
+You can download the latest version of the `ken` on [Download](download.md) page.
 
 ## Linux Archive Distribution <a id="linux-archive-distribution"></a>
 
@@ -65,7 +65,7 @@ $ yum install kend-baobab-vX.X.X.el7.x86_64.rpm
 Alternatively, you can install `kend` from the Klaytn Yum repo, run:
 
 ```text
-$ sudo curl -o /etc/yum.repos.d/klaytn.repo http://packages.klaytn.net/config/rhel/7/prod.repo && sudo yum install kend
+$ sudo curl -o /etc/yum.repos.d/klaytn.repo https://packages.klaytn.net/config/rhel/7/prod.repo && sudo yum install kend
 ```
 
 ### Installed Location <a id="installed-location"></a>


### PR DESCRIPTION
Use HTTPs for the Yum repo setup command.

This fixes the following error when installing Klaytn from the Yum repo:
```
[root@ip-172-27-103-112 ~]# sudo curl -o /etc/yum.repos.d/klaytn.repo http://packages.klaytn.net/config/rhel/7/prod.repo && sudo yum install kcnd
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   183  100   183    0     0   4255      0 --:--:-- --:--:-- --:--:--  4255
Loaded plugins: extras_suggestions, langpacks, priorities, update-motd


File contains no section headers.
file: file:///etc/yum.repos.d/klaytn.repo, line: 1
'<html>\r\n'
```