### PR TITLE
TextReview: caver.klay.KIP7.deploy ~ kip7Instance.addMinter 

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.klay.KIP7.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.klay.KIP7.md
@@ -318,7 +318,7 @@ Returns the amount of token that `spender` is allowed to withdraw from `owner`.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| owner | String | The address of the account who allowed the spender to use its token  |
+| owner | String | The address of the token owner's account.  |
 | spender | String | The address of the account that spends tokens in place of the owner. |
 
 **Return Value**
@@ -441,7 +441,7 @@ The `sendParam` object contains the following:
 
 | Name | Type | Description |
 | --- | --- | --- |
-| from | String | (optional) The address from which the transaction should be sent. If omitted, it will be set by `this.options.from`. If neither of `from` in `sendParam` object nor `this.options.from` were not provided, an error would occur. |
+| from | String | (optional) The address from which the transaction should be sent. If omitted, it will be set by `this.options.from`. If neither of `from` in the `sendParam` object nor `this.options.from` were not provided, an error would occur. |
 | gas | Number &#124; String | (optional) The maximum number of gas provided for this transaction (gas limit). If omitted, it will be set by caver-js via calling `this.methods.approve(spender, amount).estimateGas({from})`. |
 | gasPrice | Number &#124; String | (optional) The gas price in peb for this transaction. If omitted, it will be set by caver-js via calling `caver.klay.getGasPrice`. |
 | value | Number &#124; String &#124; BN &#124; BigNumber | (optional) The value to be transferred in peb. |
@@ -504,9 +504,9 @@ The `sendParam` object contains the following:
 ```javascript
 kip7Instance.transfer(recipient, amount [, sendParam])
 ```
-Transfers the given `amount` of token from the sender of the token to the `recipient`. The token owner is the sender of the token and also the sender of this transaction (`sendParam.from` or `kip7Instance.options.from`). Without `sendParam.from` nor `kip7Instance.options.from` being provided, an error would occur.  
+Transfers the given `amount` of token from the token owner's balance to the `recipient`. The token owner should execute this token transfer with its own hands. Thus, the token owner should be the sender of this transaction whose address must be given at `sendParam.from` or `kip7Instance.options.from`. Without `sendParam.from` nor `kip7Instance.options.from` being provided, an error would occur.  
 
-Note that this method will submit a transaction from the sender of the token to the Klaytn network, which will charge the transaction fee to the sender.
+Note that sending this transaction will charge the transaction fee to the transaction sender.
 
 **Parameters**
 
@@ -575,11 +575,11 @@ Note that this method will submit a transaction from the sender of the token to 
 ```javascript
 kip7Instance.safeTransfer(recipient, amount [, data] [, sendParam])
 ```
-Safely transfers the given `amount` of token from the sender of the token to the `recipient`. The token owner is the sender of the token and also the sender of this transaction (`sendParam.from` or `kip7Instance.options.from`). Without `sendParam.from` nor `kip7Instance.options.from` being provided, an error would occur.  
+Safely transfers the given `amount` of token from the token owner's balance to the `recipient`. The token owner should execute this token transfer with its own hands. Thus, the token owner should be the sender of this transaction whose address must be given at `sendParam.from` or `kip7Instance.options.from`. Without `sendParam.from` nor `kip7Instance.options.from` being provided, an error would occur.  
 
 If the recipient was a contract address, it should implement [IKIP7Receiver.onKIP7Received](https://kips.klaytn.com/KIPs/kip-7#wallet-interface). Otherwise, the transfer is reverted.  
 
-Note that this method will submit a transaction from the sender of the token to the Klaytn network, which will charge the transaction fee to the sender.
+Note that sending this transaction will charge the transaction fee to the transaction sender.
 
 **Parameters**
 
@@ -653,9 +653,9 @@ Note that this method will submit a transaction from the sender of the token to 
 ```javascript
 kip7Instance.transferFrom(sender, recipient, amount [, sendParam])
 ```
-Transfers the given `amount` of token from the `sender` to the `recipient`, by the transaction sent from the address (`sendParam.from` or `kip7Instance.options.from`) approved to spend the owner's token. Without `sendParam.from` nor `kip7Instance.options.from` being provided, an error would occur.  
+Transfers the given `amount` of token from the token owner's balance to the `recipient`. The address who was approved to dispose the token owner's tokens is expected to execute this token transferring transaction. Thus, the approved one should be the sender of this transaction whose address must be given at `sendParam.from` or `kip7Instance.options.from`. Without `sendParam.from` nor `kip7Instance.options.from` being provided, an error would occur.  
 
-Note that this method will submit a transaction from the spender, not the token owner, to the Klaytn network, which will charge the transaction fee to the transaction sender.
+Note that sending this transaction will charge the transaction fee to the transaction sender.
 
 **Parameters**
 
@@ -748,11 +748,11 @@ Note that this method will submit a transaction from the spender, not the token 
 ```javascript
 kip7Instance.safeTransferFrom(sender, recipient, amount [, data] [, sendParam])
 ```
-Safely transfers the given `amount` of token from the `sender` to the `recipient`, by the transaction sent from the address (`sendParam.from` or `kip7Instance.options.from`) approved to spend the owner's token. Without `sendParam.from` nor `kip7Instance.options.from` being provided, an error would occur.  
+Safely transfers the given `amount` of token from the token owner's balance to the `recipient`. The address who was approved to dispose the token owner's tokens is expected to execute this token transferring transaction. Thus, the approved one should be the sender of this transaction whose address must be given at `sendParam.from` or `kip7Instance.options.from`. Without `sendParam.from` nor `kip7Instance.options.from` being provided, an error would occur.  
 
 If the recipient was a contract address, it should implement [IKIP7Receiver.onKIP7Received](https://kips.klaytn.com/KIPs/kip-7#wallet-interface). Otherwise, the transfer is reverted.  
 
-Note that this method will submit a transaction from the spender, not the token owner, to the Klaytn network, which will charge the transaction fee to the transaction sender.
+Note that sending this transaction will charge the transaction fee to the transaction sender.
 
 **Parameters**
 


### PR DESCRIPTION
caver.klay.KIP7.md 파일에서 caver.klay.KIP7.deploy ~ kip7Instance.addMinter까지 리뷰입니다.
아울러 이 파일 내용에 관해 아래와 같은 질문 사항이 있습니다.

1. kip7Instance.mint 결과값으로 받는 영수증 객체의 이벤트가 'Transfer가 맞는지 궁금합니다.
2. kip7Instance.renounceMinter 결과값으로 받는 영수증 객체의 이벤트 'MinterRemoved'는 무슨 이벤트인가요? (리논스 민터가 무슨 함수인지 잘 모르겠습니다)

3. 여러 함수에서 전송할 토큰량을 나타내는 `amount`라는 파라미터 명은 불가산 명사의 수량을 나타내는 단어입니다. 혹시 quantity 같이 가산명사 수량을 표현하는 단어로 파라미터 명을 고칠 수 있나요?

4. this.options.from, this.methods.approve().estimateGas~ 에서 사용되는 this랑 kip7instance가 있는데 둘 다 같은 객체를 지칭하는 것으로 알고 있습니다. 둘 중 하나로 통일해야 하지 않을까요?

5. kip7Instance.transfer(recipient, amount [, sendParam])에서 kip7instance.options.from값이 존재하고 sendParam이 없으면 sender는 이 메소드 caller인가요 아니면 kip7instance.options.from에 지정된 address인가여?

6. kip7Instance.transferFrom에는 4가지 주체가 있습니다: 메소드 caller, sender, recipient, from(kip7instance.options.from 또는 from in sendParam).

저는 메소드 caller가 amount를 recipient에게 전송하면 해당 amount만큼 sender의 토큰양이 감소하고, caller(=spender)가 sender 계정에 대해 가지고 있는 allowance도 amount만큼 차감하는 것으로 알고 있습니다. 그런데 마지막 주체인 from은 무슨 역할을 하나요?
