### PR TITLE
CCO node spec update

### DIFF
--- a/docs/node/core-cell/system-requirements.md
+++ b/docs/node/core-cell/system-requirements.md
@@ -13,7 +13,7 @@ The following sections show the recommended specifications for both CNs and PNs.
 | Server | Intel® Server System R2312WFTZS |
 | CPU | Intel® Xeon 6148 2.40 GHz \(20-core/40-thread\) \* 2EA \(total 40-core/80-thread\) |
 | Memory | 256GB \(32GB \* 8\) |
-| Storage | 1TB (or larger size) SSD (Preferred storage size and configuration could differ depending on the chain data size. Please consult with the Klaytn team for more information.) |
+| Storage | 1TB (or larger size) SSD (The preferred storage size and configuration could differ depending on the chain data size. Please consult with the Klaytn team for more information.) |
 
 Note that this is a recommended hardware specification for CNs and PNs, not an exact requirement. Any physical machine having similar hardware configuration would be sufficient to operate a CN or a PN.
 
@@ -26,7 +26,7 @@ Note that this is a recommended hardware specification for CNs and PNs, not an e
 | CN | c5.18xlarge  | 72 | 144 | 1,000 (Minimum) | 3,000 (Minimum) | 3.456 |
 | PN | m5.8xlarge  | 32 | 128 | 1,000 (Minimum) | 3,000 (Minimum)  | 1.888 |
 
-This storage specification is derived from AWS EBS SSD (gp2). 
+This storage specification is derived from AWS EBS SSD (gp2) specification. 
 
 The information above is from [https://aws.amazon.com/ec2/instance-types/](https://aws.amazon.com/ec2/instance-types/) and [https://aws.amazon.com/ec2/pricing/on-demand/](https://aws.amazon.com/ec2/pricing/on-demand/) and may be changed by AWS.
 


### PR DESCRIPTION
PN의 노드타입을 m5.8xlarge로 변경하였습니다.

Storage용량을 늘리는 기존 PR을 함께 포함하였습니다.