### PR TITLE
test

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.utils.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.utils.md
@@ -1,3 +1,8 @@
+---
+description: >-
+  caver-js utility APIs.
+---
+
 # caver.utils <a id="caver-utils"></a>
 
 `caver.utils` provides utility functions.


### PR DESCRIPTION
summary 링크의 이상한 현상이 나타나는 것은 Getting Started와 caver.utils 2개로, 둘다 caver-js ~v1.4.1 하위에 있는 것과 이름이 동일한 메뉴입니다.

지금 이 PR로(caver.utils에 그냥 디스크립션 추가) 빌드된 깃북에서는 서머리 링크가 정상 작동하는 것 같은데 혹시 이거 머지 하고 다시 빌드 시켜봐도 될까요? 

gitbook link : https://app.gitbook.com/@klaytn/s/docs-dev/v/gitbook_summayTest