### PR TITLE
Added getAccount function documentation

### DIFF
--- a/docs/bapp/sdk/caver-js/v1.4.1/api-references/caver.klay.accounts.md
+++ b/docs/bapp/sdk/caver-js/v1.4.1/api-references/caver.klay.accounts.md
@@ -2306,7 +2306,7 @@ Returns the account corresponding to the address in `caver.klay.accounts.wallet`
 
 | Name | Type | Description |
 | --- | --- | --- |
-| addressOrIndex | String &#124; Number | An index in the wallet address list, an address in hexadecimal. The given value should exist in the caver-js wallet. |
+| addressOrIndex | String &#124; Number | An index in the wallet address list, or an address in hexadecimal. The given value should exist in the caver-js wallet. |
 
 **Return Value**
 


### PR DESCRIPTION
caver-js ~v1.4.1의 문서에서
caver.klay.accounts.wallet의 getAccount 함수가 누락되어 있어서 추가합니다.