### PR TITLE
Mis ordered parameter for klay_sign

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.rpc/klay.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.rpc/klay.md
@@ -542,7 +542,7 @@ true
 ## caver.rpc.klay.sign <a id="caver-rpc-klay-sign"></a>
 
 ```javascript
-caver.rpc.klay.sign(message, address [, blockNumber] [, callback])
+caver.rpc.klay.sign(address, message [, blockNumber] [, callback])
 ```
 
 Generates signed data specific to the Klaytn. Refer to [Klaytn Platform API - klay_sign](../../../../json-rpc/api-references/klay/account.md#klay_sign) to know how the signature is generated.
@@ -553,8 +553,8 @@ Generates signed data specific to the Klaytn. Refer to [Klaytn Platform API - kl
 
 | Name | Type | Description |
 | --- | --- | --- |
-| message | String | Message to sign. |
 | address | String | The address of the imported account to sign the message. |
+| message | String | Message to sign. |
 | blockNumber | number &#124; string | (optional) A block number, or the string `latest`, `earliest` or `pending`. If omitted, `latest` will be used. |
 | callback | function | (optional) Optional callback, returns an error object as the first parameter and the result as the second. |
 
@@ -569,7 +569,7 @@ Generates signed data specific to the Klaytn. Refer to [Klaytn Platform API - kl
 **Example**
 
 ```javascript
-> caver.rpc.klay.sign('0xdeadbeaf', '0x{address in hex}').then(console.log)
+> caver.rpc.klay.sign('0x{address in hex}', '0xdeadbeaf').then(console.log)
 0x1066e052c4be821daa4d0a0cd1e9e75ccb200bb4001c2e38853ba41b712a5a226da2acd67c86a13b266e0d75d0a6e7d1551c8924af413267615a5948617c746c1c
 ```
 


### PR DESCRIPTION
klay_sign을 호출하는 caver.rpc.klay.sign 파라미터 순서가 바뀌어 있어서 수정하는 PR입니다.

기존에 caver-js v1.5.0 이전 버전에서는 klay_sign을 호출할 때에 "transformPayload": "reversePayload" 옵션을 추가하여서 사용자가 파라미터 순서를 뒤바꿔서 넣도록 되어 있었는데, 이번 1.5.0버전부터는 플랫폼에서 제공되는 API의 파라미터 순서와 맞추고자 변경되었습니다.
문서에 반영되지 않은 것을 리포팅 받아서 수정 PR 올립니다.