### PR TITLE
Added examples for fee delegation

### DIFF
--- a/docs/bapp/sdk/caver-js/getting-started.md
+++ b/docs/bapp/sdk/caver-js/getting-started.md
@@ -1188,7 +1188,7 @@ $ node ./test.js
 }
 ```
 
-Executing a smart contract with fee delegation is not possible using the `caver.contract` currently. To do that, a feeDelegatedSmartContractExecution(WithRatio) transaction is used explicitly like below:
+Executing a smart contract through fee-delegated transaction using `caver.contract` is not supported yet. To do that, `caver.transaction.feeDelegatedSmartContractExecution` (or `caver.transaction.feeDelegatedSmartContractExecutionWithRatio`) is used explicitly like the example below:
 
 ```javascript
 // test.js


### PR DESCRIPTION
이전에 콜린이 요청하신 예제를 추가합니다.

현재 caver.contract를 사용하여 fee delegation을 할 수 없기 때문에, 따로 fee delegated smart contract deploy 혹은 fee delegated smart contract execution을 하는 예제입니다.