### PR TITLE
Fix typo in getBlock APIs

### DIFF
--- a/docs/bapp/json-rpc/api-references/klay/block.md
+++ b/docs/bapp/json-rpc/api-references/klay/block.md
@@ -108,7 +108,7 @@ This API works only on RPC call, not on Javascript console.
 
 **Return Value**
 
-`Object` - A block object, or `null` when no block was found:
+`Object` - A block object, or `error` when no block was found:
 
 | Name | Type | Description |
 | --- | --- | --- |
@@ -301,7 +301,7 @@ Returns a block with consensus information matched by the given hash.
 
 **Return Value**
 
-`Object` - A block object with consensus information (a proposer and a list of committee members), or `null` when no block was found:
+`Object` - A block object with consensus information (a proposer and a list of committee members), or `error` when no block was found:
 
 | Name | Type | Description |
 | --- | --- | ---|
@@ -405,7 +405,7 @@ Returns a block with consensus information matched by the given block number.
 
 **Return Value**
 
-`Object` - A block object with consensus information (a proposer and a list of committee members), or `null` when no block was found:
+`Object` - A block object with consensus information (a proposer and a list of committee members), or `error` when no block was found:
 
 | Name | Type | Description |
 | --- | --- | ---|


### PR DESCRIPTION
블록이 존재하지 않는경우의 return값을 실제 동작과 일치시키도록 업데이트 하였습니다.

https://groundx.atlassian.net/browse/KASQ-247