### PR TITLE
Add `optional` to `to` of `Call` API

### DIFF
--- a/docs/bapp/json-rpc/api-references/klay/transaction.md
+++ b/docs/bapp/json-rpc/api-references/klay/transaction.md
@@ -14,7 +14,7 @@ Executes a new message call immediately without creating a transaction on the bl
 | Name | Type | Description |
 | --- | --- | --- |
 | from | 20-byte DATA | (optional) The address the transaction is sent from. |
-| to | 20-byte DATA | (optional) The address the transaction is directed to. If omitted, it tests the deployment of a smart contract (no actual deployment is taken place). |
+| to | 20-byte DATA | (optional when testing the deployment of a new contract) The address the transaction is directed to. |
 | gas | QUANTITY | (optional) Integer of the gas provided for the transaction execution. `klay_call` consumes zero gas, but this parameter may be needed by some executions. |
 | gasPrice | QUANTITY | (optional) Integer of the gasPrice used for each paid gas. |
 | value | QUANTITY | (optional) Integer of the value sent with this transaction. |

--- a/docs/bapp/sdk/caver-js/api-references/caver.rpc/klay.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.rpc/klay.md
@@ -1262,7 +1262,7 @@ Executes a new message call immediately without sending a transaction on the blo
 
 | Name | Type | Description |
 | --- | --- | --- |
-| to | string | (optional) The address the transaction is directed to. If omitted, it tests the deployment of a smart contract (no actual deployment is taken place). |
+| to | string | (optional when testing the deployment of a new contract) The address the transaction is directed to. |
 | input | string | (optional) The hash of the method signature and encoded parameters. You can use [caver.abi.encodeFunctionCall](../caver.abi.md#encodefunctioncall). |
 | from | string | (optional) The address the transaction is sent from. |
 | gas | string | (optional) The gas provided for the transaction execution. `klay_call` consumes zero gas, but this parameter may be needed by some executions. |


### PR DESCRIPTION
`to` field를 optional로 처리하였습니다.

```
➜  ~ curl --location --request POST 'https://node-api.qa-2.klaytn.com/v1/klaytn' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic S0FTS0lNSjMzVzhHSFdYWks3MUI1V1Y3Olp6UTRvR01QUHpDU3R0bUZhb0FRaVBac3lwQit2ZUpyR0crdjZSWUk=' \
--header 'x-chain-id: 1001' \
--data-raw '{
    "jsonrpc": "2.0",
    "method": "klay_call",
    "params": [
        {},
        "latest"
    ],
    "id": 123
}'
{"jsonrpc":"2.0","id":123,"result":"0x"}
```

```
➜  ~ curl --location --request POST 'https://node-api.qa-2.klaytn.com/v1/klaytn' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic S0FTS0lNSjMzVzhHSFdYWks3MUI1V1Y3Olp6UTRvR01QUHpDU3R0bUZhb0FRaVBac3lwQit2ZUpyR0crdjZSWUk=' \
--header 'x-chain-id: 1001' \
--data-raw '{
    "jsonrpc": "2.0",
    "method": "klay_call",
    "params": [
        {"from": "0x03497f51c31fe8b402df0bde90fd5a85f87aa943", "data": "0x604c602c600b82828239805160001a60731460008114601c57601e565bfe5b5030600052607381538281f30073000000000000000000000000000000000000000030146080604052600080fd00a165627a7a72305820e8c1b65c97f2f4a02974285b87947dbaf62bf30a6966dada0b621bbe2ea535fe0029"},
        "latest"
    ],
    "id": 123
}'


{"jsonrpc":"2.0","id":123,"result":"0x73f51e67607822c43416ebff387462d0a9a95afbbb30146080604052600080fd00a165627a7a72305820e8c1b65c97f2f4a02974285b87947dbaf62bf30a6966dada0b621bbe2ea535fe0029"}
```