### PR TITLE
Append prefix to admin apis

### DIFF
--- a/docs/bapp/json-rpc/api-references/admin.md
+++ b/docs/bapp/json-rpc/api-references/admin.md
@@ -583,7 +583,7 @@ This method takes no parameters and returns `null` or an error whether the state
 | Client  | Method invocation             |
 | :-----: | ----------------------------- |
 | Console | `admin.stopStateMigration()`             |
-|   RPC   | `{"method": "stopStateMigration"}` |
+|   RPC   | `{"method": "admin_stopStateMigration"}` |
 
 **Parameters**
 
@@ -618,7 +618,7 @@ This method takes no parameters and returns the status of the currently running 
 | Client  | Method invocation             |
 | :-----: | ----------------------------- |
 | Console | `admin.stateMigrationStatus`             |
-|   RPC   | `{"method": "stateMigrationStatus"}` |
+|   RPC   | `{"method": "admin_stateMigrationStatus"}` |
 
 **Parameters**
 


### PR DESCRIPTION
The prefix `admin_` was missing for `admin_stopStateMigration`
and `admin_stateMigrationStatus`.