### PR TITLE
Modify Solidity Version part. Title and contents are both modified.

### DIFF
--- a/docs/smart-contract/porting-ethereum-contract.md
+++ b/docs/smart-contract/porting-ethereum-contract.md
@@ -4,10 +4,10 @@ In most cases, you can use Ethereum contracts on Klaytn without any modification
 
 ## Solidity Support <a id="solidity-support"></a>
 
-Klaytn is currently compatible with Constantinople EVM. 
-Backward **compatibility** is not guaranteed with other EVM versions on Klaytn.
-Thus, it is highly recommended to compile Solidity code with Constantinople EVM. 
-Please refer to [how to set the EVM version of solc](https://solidity.readthedocs.io/en/v0.6.0/using-the-compiler.html?highlight=compatibility#setting-the-evm-version-to-target).
+Klaytn is currently compatible with **Constantinople** Ethereum Virtual Machine (EVM) version. 
+Backward compatibility is not guaranteed with other EVM versions on Klaytn.
+Thus, it is highly recommended to compile Solidity code with the Constantinople target option. 
+Please refer to [how to set the EVM version of solc](https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target).
 
 
 An example command is shown below:


### PR DESCRIPTION
Solidity를 사용함에 있어서 주의 사항을 설명하는 문서의 Solidity Version 부분 수정
- 지원되는 Solidity version을 설명하던 것을 klaytn이 호환되는 EVM 버전을 설명하는 것으로 변경
- target option을 사용하여 호환 EVM 버전으로 컴파일하는 방법 추가
- 기존 테스트 설명의 경우 테스트하였다 정도로 간단하게 표현하였는데 이를 좀 더 자세하게 표현