### PR TITLE
Remove pending block keywords in APIs

### DIFF
--- a/docs/bapp/json-rpc/api-references/governance.md
+++ b/docs/bapp/json-rpc/api-references/governance.md
@@ -274,7 +274,7 @@ The `itemsAt` returns governance items at specific block. It is the result of pr
 
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
-| QUANTITY &#124; TAG | Integer of a block number, or the string `"earliest"`, `"latest"` or `"pending"`, as in the [default block parameter](./klay/block.md#the-default-block-parameter).
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](klay/block.md#the-default-block-parameter). |
 
 **Return Value**
 

--- a/docs/bapp/json-rpc/api-references/klay/account.md
+++ b/docs/bapp/json-rpc/api-references/klay/account.md
@@ -7,7 +7,7 @@ Returns `true` if the account associated with the address is created. It returns
 | Name | Type | Description |
 | --- | --- | --- |
 | account | 20-byte DATA | Address |
-| block number | QUANTITY &#124; TAG | Integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](./block.md#the-default-block-parameter). |
+| block number | QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -227,7 +227,7 @@ Returns the account information of a given address. There are two different acco
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
 | 20-byte DATA | Address                                                      |
-| QUANTITY &#124; TAG | Integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](./block.md#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -298,7 +298,7 @@ Returns the account key of the Externally Owned Account (EOA) of a given address
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
 | 20-byte DATA | Address                                                      |
-| QUANTITY &#124; TAG | Integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](./block.md#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -382,7 +382,7 @@ Returns the balance of the account of given address.
 | Type           | Description                                                  |
 | -------------- | ------------------------------------------------------------ |
 | 20-byte DATA | Address to check for balance.                               |
-| QUANTITY &#124; TAG | Integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](./block.md#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -413,7 +413,7 @@ Returns code at a given address.
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
 | 20-byte DATA | Address                                                      |
-| QUANTITY &#124; TAG | Integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](./block.md#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -445,7 +445,7 @@ Returns the number of transactions *sent* from an address.
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
 | 20-byte DATA | Address                                                      |
-| QUANTITY &#124; TAG | Integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](./block.md#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer block number, the string `"pending"` for the pending nonce, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -479,7 +479,7 @@ Returns `true` if an input account has a non-empty codeHash at the time of a spe
 | Name | Type | Description |
 | --- | --- | --- |
 | account | 20-byte DATA | Address |
-| block number | QUANTITY &#124; TAG | Integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](./block.md#the-default-block-parameter). |
+| block number | QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
 
 **Return Value**
 

--- a/docs/bapp/json-rpc/api-references/klay/block.md
+++ b/docs/bapp/json-rpc/api-references/klay/block.md
@@ -8,7 +8,6 @@ The following options are possible for the `defaultBlock` parameter:
 - `HEX String` - an integer block number
 - `String "earliest"` for the earliest/genesis block
 - `String "latest"` - for the latest mined block
-- `String "pending"` - for the pending state/transactions
 
 
 ## klay_blockNumber <a id="klay_blocknumber"></a>
@@ -49,7 +48,7 @@ This API works only on RPC call, not on Javascript console.
 
 | Type | Description |
 | --- | --- |
-| QUANTITY &#124; TAG | Integer of a block number, or the string `"earliest"`, `"latest"` or `"pending"`, as in the [default block parameter](#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](#the-default-block-parameter). |
 | Boolean | If `true` it returns the full transaction objects, if `false` only the hashes of the transactions. |
 
 **Return Value**
@@ -235,7 +234,7 @@ Returns the number of transactions in a block matching the given block number.
 
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
-| QUANTITY &#124; TAG | Integer of a block number, or the string `"earliest"`, `"latest"` or `"pending"`, as in the [default block parameter](#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -400,8 +399,8 @@ Returns a block with consensus information matched by the given block number.
 **Parameters**
 
 | Type | Description |
-| --- | ---|
-| QUANTITY &#124; TAG | Integer of a block number, or the string `"earliest"` or `"latest"`. |
+| --- | --- |
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -503,8 +502,8 @@ Returns a list of all validators in the committee at the specified block. If the
 **Parameters**
 
 | Name | Type | Description |
-| --- | --- | ---|
-| QUANTITY  &#124; TAG | Integer | (optional) Integer of a block number, or the string `"earliest"` or `"latest"`. |
+| --- | --- | --- |
+| QUANTITY  &#124; TAG | Integer | (optional) Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -538,8 +537,8 @@ Returns the size of the committee at the specified block. If the parameter is no
 **Parameters**
 
 | Name | Type | Description |
-| --- | --- | ---|
-| QUANTITY  &#124; TAG | Integer | (optional) Integer of a block number, or the string `"earliest"` or `"latest"`. |
+| --- | --- | --- |
+| QUANTITY  &#124; TAG | Integer | (optional) Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -571,8 +570,8 @@ Returns a list of all validators of the council at the specified block. If the p
 **Parameters**
 
 | Name | Type | Description |
-| --- | --- | ---|
-| QUANTITY  &#124; TAG | Integer | (optional) Integer of a block number, or the string `"earliest"` or `"latest"`. |
+| --- | --- | --- |
+| QUANTITY  &#124; TAG | Integer | (optional) Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -606,8 +605,8 @@ Returns the size of the council at the specified block. If the parameter is not 
 **Parameters**
 
 | Name | Type | Description |
-| --- | --- | ---|
-| QUANTITY  &#124; TAG | Integer | (optional) Integer of a block number, or the string `"earliest"` or `"latest"`. |
+| --- | --- | --- |
+| QUANTITY  &#124; TAG | Integer | (optional) Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
 
 **Return Value**
 
@@ -637,11 +636,11 @@ Returns the value from a storage position at a given address.
 
 **Parameters**
 
-| Type          | Description                                                  |
-| ------------- | ------------------------------------------------------------ |
-| 20-byte DATA | Address of the storage.                           |
-| QUANTITY      | Integer of the position in the storage.                      |
-| QUANTITY &#124; TAG | Integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](#the-default-block-parameter). |
+| Type | Description |
+| --- | --- |
+| 20-byte DATA | Address of the storage. |
+| QUANTITY | Integer of the position in the storage. |
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
 
  **Return Value**
 

--- a/docs/bapp/json-rpc/api-references/klay/filter.md
+++ b/docs/bapp/json-rpc/api-references/klay/filter.md
@@ -107,9 +107,9 @@ Returns an array of all logs matching a given filter object.
 `Object` - The filter options:
 
 | Name | Type | Description |
-| --- | --- | ---|
-| fromBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer block number, or `"latest"` for the last mined block or `"pending"`, `"earliest"` for not yet mined transactions. |
-| toBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer block number, or `"latest"` for the last mined block or `"pending"`, `"earliest"` for not yet mined transactions. |
+| --- | --- | --- |
+| fromBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
+| toBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
 | address | 20-byte DATA &#124; Array | (optional) Contract address or a list of addresses from which logs should originate. |
 | topics | Array of DATA | (optional) Array of 32-byte DATA topics. Topics are order-dependent. Each topic can also be an array of DATA with “or” options. |
 | blockHash | 32-byte DATA | (optional) A filter option that restricts the logs returned to the single block with the 32-byte hash blockHash. Using blockHash is equivalent to fromBlock = toBlock = the block number with hash blockHash. If blockHash is present in in the filter criteria, then neither fromBlock nor toBlock are allowed. |
@@ -286,8 +286,8 @@ Topics are order-dependent. A transaction with a log with topics `[A, B]` will b
 
 | Name | Type | Description |
 | --- | --- | --- |
-| fromBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer block number, or `"latest"` for the last mined block or `"pending"`, `"earliest"` for not yet mined transactions. |
-| toBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer block number, or `"latest"` for the last mined block or `"pending"`, `"earliest"` for not yet mined transactions. |
+| fromBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
+| toBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
 | address | 20-byte DATA &#124; Array | (optional) Contract address or a list of addresses from which logs should originate. |
 | topics | Array of DATA | (optional) Array of 32-byte DATA topics. Topics are order-dependent. Each topic can also be an array of DATA with "or" options. |
 

--- a/docs/bapp/json-rpc/api-references/klay/transaction.md
+++ b/docs/bapp/json-rpc/api-references/klay/transaction.md
@@ -7,7 +7,7 @@ Executes a new message call immediately without creating a transaction on the bl
 | Name | Type | Description |
 | --- | --- | --- |
 | callObject | Object | The transaction call object.  See the next table for the object's properties. |
-| blockNumber | QUANTITY &#124; TAG | Integer block number, or the string `"latest"`, `"earliest"` or `"pending"`, see the [default block parameter](./block.md#the-default-block-parameter). |
+| blockNumber | QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
 
 `callObject` has the following properties:
 
@@ -174,7 +174,7 @@ This API works only on RPC call, not on Javascript console.
 
 | Type | Description |
 | --- | --- |
-| QUANTITY &#124; TAG | A block number, or the string `"earliest"`, `"latest"` or `"pending"`, as in the [default block parameter](./block.md#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
 | QUANTITY | The transaction index position. |
 
 **Return Value**


### PR DESCRIPTION
https://github.com/klaytn/klaytn/pull/738 이 적용되면 API에서 "pending" block 파라미터를 지원하지 않습니다. 
해당 PR이 적용된 버전이 Release되진 않았지만 현재도 "pending" block은 올바르게 동작하지 않으므로 Docs 먼저 업데이트해도 될듯 합니다.

- `klay_getTransactinoCount` 를 제외한 API에서 pending 삭제 
- `default block paramter`에서 pending 삭제
- `default block paramter` 사용에 관한 설명문구 통일
- "docs/bapp/json-rpc/api-references/klay/filter.md" 파일에는 "earliest" 문구가 조금 다른 의미로 들어가 있었지만 infura를 참조하여 동일한 문구로 통일 
![image](https://user-images.githubusercontent.com/48199072/98099024-674d0b80-1ed2-11eb-8b93-098bd745a753.png)
