### PR TITLE
tracing.md: add new tracer

### DIFF
--- a/docs/bapp/json-rpc/api-references/debug/tracing.md
+++ b/docs/bapp/json-rpc/api-references/debug/tracing.md
@@ -381,6 +381,9 @@ noopTracer | noopTracer is just the barebone boilerplate code required from a Ja
 opcountTracer | opcountTracer is a sample tracer that just counts the number of instructions executed by the KLVM before the transaction terminated.
 prestateTracer | prestateTracer outputs sufficient information to create a local execution of the transaction from a custom assembled genesis block.
 revertTracer | revertTracer outputs the error string of REVERT. If the execution is not reverted, it outputs an empty string.
+unigramTracer | unigramTracer returns the number of occurrences of each opcode.
+bigramTracer | bigramTracer returns the number of occurrences of two consecutive opcodes.
+trigramTracer | trigramTracer returns the number of occurrences of three consecutive opcodes.
 
 
 **Example**


### PR DESCRIPTION
This PR is exactly same with https://github.com/ground-x/klaytn-docs/pull/239.
It is closed because `yoomee1313/klaytn-docs master` does not contain https://github.com/ground-x/klaytn-docs/commit/fd6e8043f46fca752012fdcf800ef2d2422be09d commit anymore.
Instead, I reopened this PR which including the previous contents. Sorry for the inconvenience caused by the reopening.

Three new tracers are added; unigramTracer, bigramTracer, trigramTracer.
Those tracers are opcode analysis tools.
It will be published when `klaytn v1.6.0` is released. Github label Klaytn v1.6.0 will be tagged.
