### PR TITLE
Add API descriptions about klay_subscribe and klay_unsubscribe

### DIFF
--- a/docs/bapp/json-rpc/api-references/klay/filter.md
+++ b/docs/bapp/json-rpc/api-references/klay/filter.md
@@ -358,7 +358,7 @@ If a connection is closed, all subscriptions created over the connection are rem
 
 | Type | Description |
 | --- | --- |
-| QUANTITY | A subscription id when a subscription is created. For each event that matches the subscription, a notification with relevant data will be delivered also. |
+| QUANTITY | A subscription id when a subscription is created. For each event that matches the subscription, a notification with relevant data will be delivered as well. |
 
 
 **Example**


### PR DESCRIPTION
`klay_subscribe` 와 `klay_unsubscribe` API 설명을 추가했습니다. 
geth에 존재하기 예전부터 사용 가능했던 API인데, 문서에 존재하지 않았습니다. 

이 API들은 주로 websocket으로 사용하기 적합한 API들이기에 HTTP Request 예시를 사용했던 다른 API와 달리 websocket 사용하는 예시가 첨부되어 있습니다. 

작성에 참조한 문서: 
https://geth.ethereum.org/docs/rpc/pubsub
https://infura.io/docs/ethereum#operation/eth_subscribe
https://besu.hyperledger.org/en/stable/HowTo/Interact/APIs/RPC-PubSub/