### PR TITLE
Add API descriptions about admin_setMaxSubscriptionPerWSConn

### DIFF
--- a/docs/bapp/json-rpc/api-references/admin.md
+++ b/docs/bapp/json-rpc/api-references/admin.md
@@ -694,7 +694,7 @@ $ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"ad
 
 ## admin_setMaxSubscriptionPerWSConn <a id="admin_setMaxSubscriptionPerWSConn"></a>
 
-The `setMaxSubscriptionPerWSConn` is an administrative method that sets the maximum allowed number of subscriptions per single WebSocket connection. For example, if the maximum number is set to five and a user requests more than five subscriptions through the `klay_subscribe` API, an error message "Maximum 5 subscriptions are allowed for a WebSocket connection" will be displayed.
+The `setMaxSubscriptionPerWSConn` is an administrative method that sets the maximum allowed number of subscriptions per single WebSocket connection. For example, if the maximum number is set to five and a user requests more than five subscriptions through the `klay_subscribe` API, an error message "Maximum 5 subscriptions are allowed for a WebSocket connection" will be displayed. This feature is supported since Klaytn 1.6.0.
 
 | Client  | Method invocation                                            |
 | :-----: | ------------------------------------------------------------ |


### PR DESCRIPTION
Release 준비 중인 Klaytn v1.6에 추가되는 API 설명입니다. 
`admin_setMaxSubscriptionPerWSConn` API는 하나의 Websocket 연결마다 허용되는 최대 subscription 수를 설정할 수 있습니다. 

관련 PR: https://github.com/klaytn/klaytn/pull/850 https://github.com/klaytn/klaytn/pull/897