### PR TITLE
[istanbul change] istanbul hardfork related changed added

### DIFF
--- a/docs/klaytn/design/computation/computation-cost.md
+++ b/docs/klaytn/design/computation/computation-cost.md
@@ -14,6 +14,9 @@ Therefore, we chose the third option and implemented it in Klaytn. For now, the 
 
 The below table shows the computation cost of EVM opcodes. The computation cost was determined based on experiments.
 
+In the process of importing Ethereum Istanbul hardfork, some computation costs are changed. Please refer to the table below for computation cost change. 
+If there's any change, they are marked as follows: [Original, Istanbul].
+
 | Opcode | ComputationCost |
 | :--- | ---: |
 | STOP | 0 |
@@ -44,7 +47,7 @@ The below table shows the computation cost of EVM opcodes. The computation cost 
 | SAR | 1815 |
 | SHA3 | 2465 |
 | ADDRESS | 284 |
-| BALANCE | 1407 |
+| BALANCE | 1407, 2462 |
 | ORIGIN | 210 |
 | CALLER | 188 |
 | CALLVALUE | 149 |
@@ -58,18 +61,20 @@ The below table shows the computation cost of EVM opcodes. The computation cost 
 | EXTCODECOPY | 1000 |
 | RETURNDATASIZE | 10 |
 | RETURNDATACOPY | 40 |
-| EXTCODEHASH | 1000 |
+| EXTCODEHASH | 1000, 1750 |
 | BLOCKHASH | 500 |
 | COINBASE | 189 |
 | TIMESTAMP | 265 |
 | NUMBER | 202 |
 | DIFFICULTY | 180 |
 | GASLIMIT | 166 |
+| CHAINID | 130 |
+| SELFBALANCE | 179 |
 | POP | 140 |
 | MLOAD | 376 |
 | MSTORE | 288 |
 | MSTORE8 | 5142 |
-| SLOAD | 835 |
+| SLOAD | 835, 3340 |
 | SSTORE | 1548 |
 | JUMP | 253 |
 | JUMPI | 176 |

--- a/docs/klaytn/design/computation/klaytn-virtual-machine.md
+++ b/docs/klaytn/design/computation/klaytn-virtual-machine.md
@@ -92,6 +92,9 @@ Storage fees have a slightly nuanced behavior. To incentivize minimization of th
 
 The fee schedule `G` is a tuple of 37 scalar values corresponding to the relative costs, in gas, of a number of abstract operations that a transaction may incur. For other tables such as `Precompiled contracts` and `accounts`, please refer to [this document](../transaction-fees.md#klaytns-gas-table)
 
+In the process of importing Ethereum Istanbul hardfork, some gas costs are changed. Please refer to the table below for gas cost change. 
+If there's any change, they are marked as follows: [Original, Istanbul].
+
 | Name | Value | Description |
 | :--- | ---: | :--- |
 | `G_zero` | 0 | Nothing paid for operations of the set `W_zero` |
@@ -102,8 +105,8 @@ The fee schedule `G` is a tuple of 37 scalar values corresponding to the relativ
 | `G_high` | 10 | Amount of gas paid for operations of the set `W_high` |
 | `G_blockhash` | 20 | Payment for a `BLOCKHASH` operation |
 | `G_extcode` | 700 | Amount of gas paid for operations of the set `W_extcode` |
-| `G_balance` | 400 | Amount of gas paid for a `BALANCE` operation |
-| `G_sload` | 200 | Amount of gas paid for an `SLOAD` operation |
+| `G_balance` | 400, 700 | Amount of gas paid for a `BALANCE` operation |
+| `G_sload` | 200, 800 | Amount of gas paid for an `SLOAD` operation |
 | `G_jumpdest` | 1 | Amount of gas paid for a `JUMPDEST` operation |
 | `G_sset` | 20000 | Amount of gas paid for an `SSTORE` operation when the storage value is set to nonzero from zero |
 | `G_sreset` | 5000 | Amount of gas paid for an `SSTORE` operation when the storage value remains unchanged at zero or is set to zero |
@@ -121,7 +124,7 @@ The fee schedule `G` is a tuple of 37 scalar values corresponding to the relativ
 | `G_memory` | 3 | Amount of gas paid for every additional word when expanding memory |
 | `G_txcreate` | 32000 | Amount of gas paid by all contract-creating transactions |
 | `G_txdatazero` | 4 | Amount of gas paid for every zero byte of data or code for a transaction |
-| `G_txdatanonzero` | 68 | Amount of gas paid for every nonzero byte of data or code for a transaction |
+| `G_txdatanonzero` | 68, 16 | Amount of gas paid for every nonzero byte of data or code for a transaction |
 | `G_transaction` | 21000 | Amount of gas paid for every transaction |
 | `G_log` | 375 | Partial payment for a `LOG` operation |
 | `G_logdata` | 8 | Amount of gas paid for each byte in a `LOG` operation's data |
@@ -129,15 +132,15 @@ The fee schedule `G` is a tuple of 37 scalar values corresponding to the relativ
 | `G_sha3` | 30 | Amount of gas paid for each `SHA3` operation |
 | `G_sha3word` | 6 | Amount of gas paid for each word \(rounded up\) for input data to a `SHA3` operation |
 | `G_copy` | 3 | Partial payment for `COPY` operations, multiplied by words copied, rounded up |
-| `G_extcodehash` | 400 | Paid for getting `keccak256` hash of a contract's code |
+| `G_extcodehash` | 400, 700 | Paid for getting `keccak256` hash of a contract's code |
 | `G_create2` | 32000 | Paid for opcode `CREATE2` which bahaves identically with CREATE but use different arguments |
 
 We define the following subsets of instructions:
 
 * `W_zero` = {`STOP`, `RETURN`, `REVERT`}
-* `W_base` = {`ADDRESS`, `ORIGIN`, `CALLER`, `CALLVALUE`, `CALLDATASIZE`, `CODESIZE`, `GASPRICE`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `DIFFICULTY`, `GASLIMIT`, `RETURNDATASIZE`, `POP`, `PC`, `MSIZE`, `GAS`}
+* `W_base` = {`ADDRESS`, `ORIGIN`, `CALLER`, `CALLVALUE`, `CALLDATASIZE`, `CODESIZE`, `GASPRICE`, `COINBASE`, `TIMESTAMP`, `NUMBER`, `DIFFICULTY`, `GASLIMIT`, `RETURNDATASIZE`, `POP`, `PC`, `MSIZE`, `GAS`, `CHAINID`}
 * `W_verylow` = {`ADD`, `SUB`, `LT`, `GT`, `SLT`, `SGT`, `EQ`, `ISZERO`, `AND`, `OR`, `XOR`, `NOT`, `BYTE`, `CALLDATALOAD`, `MLOAD`, `MSTORE`, `MSTORE8`, `PUSH`, `DUP`, `SWAP`}
-* `W_low` = {`MUL`, `DIV`, `SDIV`, `MOD`, `SMOD`, `SIGNEXTEND`}
+* `W_low` = {`MUL`, `DIV`, `SDIV`, `MOD`, `SMOD`, `SIGNEXTEND`, `SELFBALANCE`}
 * `W_mid` = {`ADDMOD`, `MULMOD`, `JUMP`}
 * `W_high` = {`JUMPI`}
 * `W_extcode` = {`EXTCODESIZE`}

--- a/docs/klaytn/design/transaction-fees.md
+++ b/docs/klaytn/design/transaction-fees.md
@@ -43,6 +43,9 @@ Klaytn currently does not provide a way to replace a transaction using the unit 
 
 Basically, Klaytn is keeping compatibility with Ethereum. So Klaytn's gas table is pretty similar with that of Ethereum. But because of the existence of unique features of Klaytn, there are several new constants for those features.
 
+In the process of importing Ethereum Istanbul hardfork, some gas costs are changed. Please refer to the table below for gas cost change. 
+If there's any change, they are marked as follows: [Original, Istanbul].
+
 ### Common Fee <a id="common-fee"></a>
 
 | Item | Gas | Description |
@@ -55,8 +58,8 @@ Basically, Klaytn is keeping compatibility with Ethereum. So Klaytn's gas table 
 | G\_high | 10 | Amount of gas to pay for operations of the set Whigh |
 | G\_blockhash | 20 | Payment for BLOCKHASH operation |
 | G\_extcode | 700 | Amount of gas to pay for operations of the set Wextcode |
-| G\_balance | 400 | Amount of gas to pay for a BALANCE operation |
-| G\_sload | 200 | Paid for a SLOAD operation |
+| G\_balance | 400, 700 | Amount of gas to pay for a BALANCE operation |
+| G\_sload | 200, 800 | Paid for a SLOAD operation |
 | G\_jumpdest | 1 | Paid for a JUMPDEST operation |
 | G\_sset | 20000 | Paid for an SSTORE operation when the storage value is set to non-zero from zero |
 | G\_sreset | 5000 | Paid for an SSTORE operation when the storage value’s zeroness remains unchanged or is set to zero |
@@ -81,7 +84,7 @@ Basically, Klaytn is keeping compatibility with Ethereum. So Klaytn's gas table 
 | G\_sha3word | 6 | Paid for each word \(rounded up\) for input data to a SHA3 operation |
 | G\_copy | 3 | Partial payment for \*COPY operations, multiplied by words copied, rounded up |
 | G\_blockhash | 20 | Payment for BLOCKHASH operation |
-| G\_extcodehash | 400 | Paid for getting keccak256 hash of a contract's code |
+| G\_extcodehash | 400, 700 | Paid for getting keccak256 hash of a contract's code |
 | G\_create2 | 32000 | Paid for opcode CREATE2 which bahaves identically with CREATE but use different arguments |
 
 ### Precompiled Contracts <a id="precompiled-contracts"></a>
@@ -98,10 +101,10 @@ Precompiled contracts are special kind of contracts which usually perform comple
 | IdentityBaseGas | 15 | ​ |
 | IdentityPerWordGas | 3 | ​ |
 | ModExpQuadCoeffDiv | 20 | ​ |
-| Bn256AddGas | 500 | Perform Bn256 elliptic curve operation |
-| Bn256ScalarMulGas | 40000 | ​ |
-| Bn256PairingBaseGas | 100000 | ​ |
-| Bn256PairingPerPointGas | 80000 | ​ |
+| Bn256AddGas | 500, 150 | Perform Bn256 elliptic curve operation |
+| Bn256ScalarMulGas | 40000, 6000 | ​ |
+| Bn256PairingBaseGas | 100000, 45000 | ​ |
+| Bn256PairingPerPointGas | 80000, 34000 | ​ |
 | VMLogBaseGas | 100 | Write logs to node's log file - Klaytn only |
 | VMLogPerByteGas | 20 | Klaytn only |
 | FeePayerGas | 300 | Get feePayer's address - Klaytn only |

--- a/docs/node/service-chain/references/genesis.md
+++ b/docs/node/service-chain/references/genesis.md
@@ -26,6 +26,7 @@ The `config` field stores the information related to the chain.
 |           Field Name           |         Description           |
 | ------------------------------ | ----------------------------- |
 | chainId                        | It identifies the current chain and is used for prevention from the replay attack. |
+| istanbulCompatibleBlock        | A block number to which istanbul change is applied. |
 | istanbul, clique               | The type of consensus engine. |
 | unitPrice                      | Unit price. |
 | deriveShaImpl                  | Defines a method to generate transaction hash and receipt hash. |
@@ -112,6 +113,7 @@ The `reward` field stores the information about the network's token economy.
 {
     "config": {
         "chainId": 2019,
+        "istanbulCompatibleBlock": 60000000,
         "istanbul": {
             "epoch": 604800,
             "policy": 2,

--- a/docs/smart-contract/porting-ethereum-contract.md
+++ b/docs/smart-contract/porting-ethereum-contract.md
@@ -5,16 +5,16 @@ However, be aware of the following two issues.
 
 ## Solidity Support <a id="solidity-support"></a>
 
-Klaytn is currently compatible with **Constantinople** Ethereum Virtual Machine (EVM) version. 
+Klaytn is currently compatible with **Istanbul** Ethereum Virtual Machine (EVM) version. 
 Backward compatibility is not guaranteed with other EVM versions on Klaytn.
-Thus, it is highly recommended to compile Solidity code with the Constantinople target option. 
+Thus, it is highly recommended to compile Solidity code with the Istanbul target option. 
 Please refer to [how to set the EVM version of solc](https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target).
 
 
 An example command is shown below:
 
 ```
-$ solc --evm-version constantinople contract.sol
+$ solc --evm-version istanbul contract.sol
 ```
 
 ## Decoupled Key Pairs <a id="decoupled-key-pairs"></a>

--- a/docs/smart-contract/solidity-smart-contract-language.md
+++ b/docs/smart-contract/solidity-smart-contract-language.md
@@ -6,7 +6,7 @@ This chapter describes only the high-level concepts, development processes, and 
 
 [Solidity](https://github.com/ethereum/solidity) is a high-level, statically typed, contract-oriented language for implementing smart contracts on the Ethereum platform. Although Solidity was originally designed for Ethereum, it is general enough to write smart contracts; therefore, it can also be used for other blockchain platforms, such as Klaytn.
 
-Klaytn is officially compatible with **Constantinople** Ethereum Virtual Machine (EVM) version. Backward compatibility is not guaranteed with other EVM versions on Klaytn. Thus, it is highly recommended to compile Solidity code with the Constantinople target option. Please refer to [how to set the EVM version of solc](https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target).
+Klaytn is officially compatible with **Istanbul** Ethereum Virtual Machine (EVM) version. Backward compatibility is not guaranteed with other EVM versions on Klaytn. Thus, it is highly recommended to compile Solidity code with the Constantinople target option. Please refer to [how to set the EVM version of solc](https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target).
  
  Development tools such as [Remix](https://remix.ethereum.org/) \(a browser-based IDE\) and [Truffle](https://github.com/trufflesuite/truffle) \(a development framework\) can be utilized when developing smart contracts for Klaytn. The Klaytn team will attempt to maintain compatibility between Ethereum's development tools and Klaytn's but may elect to provide the Klaytn smart contract developers with enhanced or updated versions of those tools when necessary.
 


### PR DESCRIPTION
이스탄불 하드포크에서 추가된 precompiled contract와 opcode를 지원하기 위해 관련 변경을 가져왔으며 그와 관련하여 문서 변경이 필요하여 해당 PR을 작성합니다.
지금은 머지하지 않으며 추후 이스탄불 변경이 작동되면 최종리뷰 후 머지할 예정입니다!

변경내용
* `istanbulCompatibleBlock` 필드를 chainConfig에 추가 (genesis.md)
* solidity compatibility: constantinople -> istanbul(porting-ethereum-contract.md, solidity-smart-contract-language.md)
* new precompiled contract: blake2b(precompiled-contracts.md, transaction-fees.md)
* new opcode: chainid&selfBalance(klaytn-virtual-machine.md, computation-cost.md, transaction-fees.md)