### PR TITLE
Added connected event emitter in docs

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.contract.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.contract.md
@@ -682,7 +682,7 @@ The options object can contain the following:
 | connected | string | Fires once after the subscription successfully connected. It returns the subscription ID. |
 | error | object | Fires when an error in the subscription occurs. |
 
-**NOTE** `connected` is supported since caver-js [v1.5.7](https://www.npmjs.com/package/caver-js/v/1.5.7).
+**NOTE** `connected` is available with caver-js [v1.5.7](https://www.npmjs.com/package/caver-js/v/1.5.7).
 
 The structure of the returned event `object` looks as follows:
 


### PR DESCRIPTION
Subscription이 성공적으로 연결된 경우 subscription id를 리턴하는 'connected' 이벤트가 새롭게 추가되었습니다.
이에 따라서 subscription을 사용하는 caver.contract에도 이 내용에 대한 문서를 추가하였습니다.