### PR TITLE
add kct detect interface contents

### DIFF
--- a/docs/bapp/sdk/caver-java/getting-started.md
+++ b/docs/bapp/sdk/caver-java/getting-started.md
@@ -1195,18 +1195,18 @@ The interface detected through `detectInterface()` for `KIP7` is shown in the ta
 |IKIP7Pausable|0x4d5507ff|
 
 ```java
-//using static method.
 Caver caver = new Caver(Caver.DEFAULT_URL);
-
+ObjectMapper mapper = new ObjectMapper();
 String contractAddress = "0x{address}";
+
+//using static method.
 Map<String, Boolean> resultStatic = KIP7.detectInterface(caver, contractAddress);
-resultStatic.entrySet().forEach(entry -> System.out.println(entry.getKey() + " - " + entry.getValue()));
+String resultJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(resultStatic);
+System.out.println(resultJson);
 
 //using instance method.
 KIP7 kip7 = new KIP7(caver, contractAddress)
 Map<String, Boolean> resultInstance = kip7.detectInterface();
-
-ObjectMapper mapper = new ObjectMapper();
 String resultJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(resultInstance);
 System.out.println(resultJson);
 ```
@@ -1244,18 +1244,19 @@ The interface detect through `detectInterface()` for `KIP17` is shown in the tab
 |IKIP17Pausable|0x4d5507ff|
 
 ```java
-//using static method.
-Caver caver = new Caver(Caver.DEFAULT_URL);
 
+Caver caver = new Caver(Caver.DEFAULT_URL);
+ObjectMapper mapper = new ObjectMapper();
 String contractAddress = "0x{address}";
+
+//using static method.
 Map<String, Boolean> resultStatic = KIP17.detectInterface(caver, contractAddress);
-resultStatic.entrySet().forEach(entry -> System.out.println(entry.getKey() + " - " + entry.getValue()));
+String resultJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(resultStatic);
+System.out.println(resultJson);
 
 //using instance method.
 KIP17 kip17 = new KIP17(caver, contractAddress)
 Map<String, Boolean> resultInstance = kip17.detectInterface();
-
-ObjectMapper mapper = new ObjectMapper();
 String resultJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(resultInstance);
 System.out.println(resultJson);
 ```
@@ -1293,18 +1294,19 @@ The interface detection through `detectInterface()` for `KIP37` is shown in the 
 
 
 ```java
-//using static method.
-Caver caver = new Caver(Caver.DEFAULT_URL);
 
+Caver caver = new Caver(Caver.DEFAULT_URL);
+ObjectMapper mapper = new ObjectMapper();
 String contractAddress = "0x{address}";
+
+//using static method.
 Map<String, Boolean> resultStatic = KIP37.detectInterface(caver, contractAddress);
-resultStatic.entrySet().forEach(entry -> System.out.println(entry.getKey() + " - " + entry.getValue()));
+String resultJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(resultStatic);
+System.out.println(resultJson);
 
 //using instance method.
-KIP37 kip37 = new KIP17(caver, contractAddress)
+KIP37 kip37 = new KIP37(caver, contractAddress)
 Map<String, Boolean> resultInstance = kip37.detectInterface();
-
-ObjectMapper mapper = new ObjectMapper();
 String resultJson = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(resultInstance);
 System.out.println(resultJson);
 ```


### PR DESCRIPTION
caver v1.5.7에 신규로 추가된 기능인 KCT detection기능을 caver-java getting started문서에 추가하였습니다.
리뷰 부탁드리겠습니다.

아래 내용은 국문 원문입니다.

## Detect KCT interface<a id="detect kct interface"></a>

[KIP-7], [KIP-17], [KIP-37]와 같은 KCT(Klaytn Compatible Token) contract는 여러 interface를 정의하고 제공하고 있으며, [KIP-13]은 KCT Contract에 질의(Query)를 보내서 이 Contract가 어떤 스펙을 준수하는 Contract인지, 어떤 Interface를 구현했는지 확인할 수 있는 내용을 담고 있습니다.

Caver v1.5.7에서 [KIP-13]의 내용을 구현하였으며, 각 KCT Contract class(KIP7, KIP17, KIP37)에 구현되어있는 detectInterface() method를 통해서 각 Contract에 구현되어 있는 인터페이스가 무엇인지 확인할 수 있습니다. 

### Detect interface implemented in KIP-7 

KIP-7 token contract에서 구현된 interface를 확인하기위해서는 KIP7 class의 구현된 detectInterface()라는 method를 사용합니다.
detectInterface()는 Map형태로 KIP-7 interface identifier와 interface 지원여부를 맵핑하여 리턴합니다.

이 detectInterface는 static method와 instance method둘다 지원하니, 상황에 맞게 사용할 method를 선택해서 사용하면 됩니다.

KIP7에서 detectInterface()를 통해 확인하는 interface는 아래 테이블과 같습니다.

|Interface|KIP-13 Identifier|
|---|---|
|IKIP7|0x65787371|
|IKIP7Metadata|0xa219a025|
|IKIP7Mintable|0xeab83e20|
|IKIP7Burnable|0x3b5a0bf8|
|IKIP7Pausable|0x4d5507ff|

```java
//using static method.
Caver caver = new Caver(Caver.DEFAULT_URL);

String contractAddress = "0x{address}";
Map<String, Boolean> resultStatic = KIP7.detectInterface(caver, contractAddress);
resultStatic.entrySet().forEach(entry -> System.out.println(entry.getKey() + " - " + entry.getValue()));

//using instance method.
KIP7 kip7 = new KIP7(caver, contractAddress)
Map<String, Boolean> resultInstance = kip7.detectInterface();
resultInstance.entrySet().forEach(entry -> System.out.println(entry.getKey() + " - " + entry.getValue()));
```

위 코드를 실행하면 아래와 같은 결과를 얻을 수 있습니다.
```java
IKIP7Metatdata - true
IKIP7Burnable - true
IKIP7 - true
IKIP7Pausable - true
IKIP7Mintable - true
```

### Detect interface implemented in KIP-17 

KIP-17 token contract에서 구현된 interface를 확인하기위해서는 KIP17 class의 구현된 detectInterface()라는 method를 사용합니다.
detectInterface()는 Map형태로 KIP-17 interface identifier와 interface 지원여부를 맵핑하여 리턴합니다.

이 detectInterface는 static method와 instance method둘다 지원하니, 상황에 맞게 사용할 method를 선택해서 사용하면 됩니다.

KIP17에서 detectInterface()를 통해 확인하는 interface는 아래 테이블과 같습니다.

|Interface|KIP-13 Identifier|
|---|---|
|IKIP17|0x80ac58cd|
|IKIP17Metadata|0x5b5e139f|
|IKIP17Enumerable|0x780e9d63|
|IKIP17Mintable|0xeab83e20|
|IKIP17MetadataMintable|0xfac27f46|
|IKIP17Burnable|0x42966c68|
|IKIP17Pausable|0x4d5507ff|

```java
//using static method.
Caver caver = new Caver(Caver.DEFAULT_URL);

String contractAddress = "0x{address}";
Map<String, Boolean> resultStatic = KIP17.detectInterface(caver, contractAddress);
resultStatic.entrySet().forEach(entry -> System.out.println(entry.getKey() + " - " + entry.getValue()));

//using instance method.
KIP17 kip17 = new KIP17(caver, contractAddress)
Map<String, Boolean> resultInstance = kip17.detectInterface();
resultInstance.entrySet().forEach(entry -> System.out.println(entry.getKey() + " - " + entry.getValue()));
```

위 코드를 실행하면 아래와 같은 결과를 얻을 수 있습니다.

```java
IKIP17Enumerable - true
IKIP17Metadata - true
IKIP17Burnable - true
IKIP17Mintable - true
IKIP17 - true
IKIP17MetadataMintable - true
IKIP17Pausable - true
```

### Detect interface implemented in KIP-37 

KIP-37 token contract에서 구현된 interface를 확인하기위해서는 KIP37 class의 구현된 detectInterface()라는 method를 사용합니다.
detectInterface()는 Map형태로 KIP-37 interface identifier와 interface 지원여부를 맵핑하여 리턴합니다.

이 detectInterface는 static method와 instance method둘다 지원하니, 상황에 맞게 사용할 method를 선택해서 사용하면 됩니다.

KIP37에서 detectInterface()를 통해 확인하는 interface는 아래 테이블과 같습니다.

| Interface | KIP-13 Identifier |
|---|---|
| IKIP37 | 0x6433ca1f |
| IKIP37Metadata] | 0x0e89341c |
| IKIP37Mintable] | 0xdfd9d9ec |
| IKIP37Burnable] | 0x9e094e9e |
| IKIP37Pausable] | 0x0e8ffdb7 |


```java
//using static method.
Caver caver = new Caver(Caver.DEFAULT_URL);

String contractAddress = "0x{address}";
Map<String, Boolean> resultStatic = KIP37.detectInterface(caver, contractAddress);
resultStatic.entrySet().forEach(entry -> System.out.println(entry.getKey() + " - " + entry.getValue()));

//using instance method.
KIP37 kip37 = new KIP17(caver, contractAddress)
Map<String, Boolean> resultInstance = kip37.detectInterface();
resultInstance.entrySet().forEach(entry -> System.out.println(entry.getKey() + " - " + entry.getValue()));
```

위 코드를 실행하면 아래와 같은 결과를 얻을 수 있습니다.

```java
IKIP37Metatdata - true
IKIP37Burnable - true
IKIP37 - true
IKIP37Pausable - true
IKIP37Mintable - true
```

