### PR TITLE
Update supported node version

### DIFF
--- a/docs/bapp/sdk/caver-js/getting-started.md
+++ b/docs/bapp/sdk/caver-js/getting-started.md
@@ -18,7 +18,7 @@ The following packages are required to use the caver-js library.
 - lts/erbium ([12.21.0](https://nodejs.org/dist/latest-v12.x/))
 - lts/fermium ([14.16.0](https://nodejs.org/dist/latest-v14.x/))
 
-If you are already using a different version of the Node \(for example, Node v15\), use the Node Version Manager\([NVM](https://github.com/nvm-sh/nvm)\) to install and use the version supported by caver-js.
+If you use a different version of the Node \(for example, Node v15\), utilize the Node Version Manager\([NVM](https://github.com/nvm-sh/nvm)\) to install and use the version supported by caver-js.
 
 ### Installation <a id="installation"></a>
 


### PR DESCRIPTION
caver-js 지원되는 노드 버전에 대한 정보를 수정합니다.
관련 논의 내용은 [여기](https://groundx.atlassian.net/wiki/spaces/PG/pages/1719926830)에 정리되어 있습니다.