### PR TITLE
Update uri function description

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.kct/kip37.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.kct/kip37.md
@@ -236,9 +236,6 @@ kip37.uri(id)
 ```
 Returns distinct Uniform Resource Identifier (URI) of the given token.
 
-If the string "{id}" exists in any URI, this function will replace this with the actual token ID in hexadecimal form.
-Please refer to [KIP-34 Metadata](http://kips.klaytn.com/KIPs/kip-37#metadata).
-
 **Parameters**
 
 | Name | Type | Description |
@@ -255,7 +252,7 @@ Please refer to [KIP-34 Metadata](http://kips.klaytn.com/KIPs/kip-37#metadata).
 
 ```javascript
 > kip37.uri('0x0').then(console.log)
-'https://caver.example/0000000000000000000000000000000000000000000000000000000000000000.json'
+'https://caver.example/{id}.json'
 ```
 
 


### PR DESCRIPTION
caver.kct.kip37의 `uri`함수에 버그 있어서 수정한 내용입니다.

- 기존 동작 : uri string에 `{id}`가 있으면 이를 token id로 replace하여 리턴
- 현재 동작 : replacement 없이 스트링 그대로 리턴