### PR TITLE
Added caver.contract fee delegation feature

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.contract.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.contract.md
@@ -562,7 +562,7 @@ The transaction type used for this function depends on the `options` or the valu
 | Name | Type | Description |
 | --- | --- | --- |
 | options | object | The options used for sending. See the table in [methods.methodName.send](#methods-methodname-send) for the details. |
-| methodName | string | The method name of the contract function to execute. If you want to sign a transaction for deploying the smart contract, use `constructor` string instead of method name. |
+| methodName | string | The method name of the contract function to execute. If you want to sign a transaction for deploying the smart contract, use 'constructor' string instead of method name. |
 | parameters | Mixed | (optional) The parameters that get passed to the smart contract function. If you want to sign a smart contract deploy transaction, pass the byteCode and constructor parameters. |
 
 **Return Value**
@@ -714,7 +714,7 @@ The transaction type used for this function depends on the `options` or the valu
 | Name | Type | Description |
 | --- | --- | --- |
 | options | object | The options used for sending. See the table in [methods.methodName.send](#methods-methodname-send) for the details. |
-| methodName | string | The method name of the contract function to execute. If you want to sign a transaction for deploying the smart contract, use `constructor` string instead of method name. |
+| methodName | string | The method name of the contract function to execute. If you want to sign a transaction for deploying the smart contract, use 'constructor' string instead of method name. |
 | parameters | Mixed | (optional) The parameters that get passed to the smart contract function. If you want to sign a smart contract deploy transaction, pass the byteCode and constructor parameters. |
 
 **Return Value**


### PR DESCRIPTION
caver-js의 `caver.contract`에 fee delegation 기능이 추가된 것에 대한 문서입니다.

아래의 변경사항이 있습니다.
- options에 FD관련 추가 필드 정의 가능. `contract.options`에 `feeDelegation`, `feePayer` 그리고 `feeRatio`를 정의할 수 있으며, `contract.options`에 이러한 값들이 정의되어 있는 경우 트랜잭션을 생성할 때에 사용자가 이러한 값들을 따로 정의하지 않으면 `contract.options`의 값들을 사용합니다.
- 기존에 제공되던 함수에서 FD관련된 옵션 필드가 추가로 정의된 경우 핸들링 추가
- `contract.deploy`, `contract.send`, `contract.sign`, `contract.signAsFeePayer`, `contract.call` 함수 추가 제공
- `contract.methods['methodName']`은 원래 스마트 컨트랙트를 실행할 때에만 사용되었으나 'methodName' 자리에 'constructor'가 오면(예 `contract.methods['constructor'](byteCode, ...)`) 스마트 컨트랙트를 배포하는 경우로 핸들링 할 수 있도록 사용성 추가 제공. 
- `contract.methods['methodName'].sign`, `contract.methods['methodName'].signAsFeePayer` 추가 제공