### PR TITLE
added caver-java contract fee delegation example.

### DIFF
--- a/docs/bapp/sdk/caver-java/getting-started.md
+++ b/docs/bapp/sdk/caver-java/getting-started.md
@@ -897,7 +897,7 @@ ContractAddress : 0x3466D49256b0982E1f240b64e097FF04f99Ed4b9
 
 A smart contract can be deployed using one of the following classes, depending on the type of contract deploying transaction:
   - `Contract` class in the `caver.contract` package when the sender or the fee payer of a smart contract transaction pays the fee
-  - `SmartContractDeploy` class in `caver.transaction` when the sender of a smart contract transaction pays the fee
+  - `SmartContractDeploy` class in the `caver.transaction` package when the sender of a smart contract transaction pays the fee
   - `feeDelegatedSmartContractDeploy` class in the `caver.transaction` package  when the fee payer of a smart contract transaction pays the fee
   - `feeDelegatedSmartContractDeployWithRatio` class in the `caver.transaction` package when the fee payer of a smart contract transaction pays the fee
 


### PR DESCRIPTION
caver-java v1.6.1에 contract를 배포 및 실행시 수수료 대납기능이 추가되었습니다.
caver-java v1.6.1 release에 맞춰 Klaytn docs의 caver-java getting started문서를 수정하는 PR입니다. 

현재 [사용성 개선과 관련된 caver-java getting started문서 수정 PR](https://github.com/ground-x/klaytn-docs/pull/279)이 올라가 있는 상태라 추후 master branch에 merge시, conflict이 나는 것을 방지하기 위해 이 [PR](https://github.com/ground-x/klaytn-docs/pull/279)의 branch를 base로 작업을 했습니다. 

제가 수정 작업한 내용은 아래에서 확인하실 수 있습니다.
https://github.com/ground-x/klaytn-docs/commit/58c2f6bad84167bfbd0bf7ba0e3de86537af0e09

헷갈리시면 이야기해주세요. 다시 PR만들도록 하겠습니다. 

**리뷰가 완료된 후 이 PR은 #279 가 머지된 이후에 머지되어야 합니다.**