### PR TITLE
Add limitation of klay_getLogs and klay_getFilterLogs APIs

### DIFF
--- a/docs/bapp/json-rpc/api-references/klay/filter.md
+++ b/docs/bapp/json-rpc/api-references/klay/filter.md
@@ -63,9 +63,9 @@ returned by other filter creation functions, such as [klay_newBlockFilter](#klay
 or [klay_newPendingTransactionFilter](#klay_newpendingtransactionfilter),
 cannot be used with this function.
 
-The execution of this API can be limited by two node configurations to manage resource of Klaytn node safely.
-- The number of returned results in a single query (default: 10,000).
-- The execution duration of ta single query (default: 10 seconds).
+The execution of this API can be limited by two node configurations to manage resources of Klaytn node safely.
+- The number of maximum returned results in a single query (Default: 10,000).
+- The execution duration limit of a single query (Default: 10 seconds).
 
 **Parameters**
 
@@ -106,9 +106,9 @@ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay
 
 Returns an array of all logs matching a given filter object.
 
-The execution of this API can be limited by two node configurations to manage resource of Klaytn node safely.
-- The number of returned results in a single query (default: 10,000).
-- The execution duration of ta single query (default: 10 seconds).
+The execution of this API can be limited by two node configurations to manage resources of Klaytn node safely.
+- The number of maximum returned results in a single query (Default: 10,000).
+- The execution duration limit of a single query (Default: 10 seconds).
 
 **Parameters**
 


### PR DESCRIPTION
v1.6.x 버전부터 2개의 API 실행 제한 조건이 추가되었습니다. 
default로 제한이 적용되어 있기에 docs에 설명 추가합니다. 

**제약 조건 도입 배경**
`klay_getLogs` API를 악용할 경우 0~latest block까지의 모든 log를 요청할 수 있음
이 행위는 EN/KES 리소스를 굉장히 낭비시킬 수 있으며, OOM 문제도 야기할 수 있음

**추가 정보**
제약 조건은 설정 가능한 값이므로 Node flag를 이용해서 변경할 수 있음