### PR TITLE
Added new functions in caver.transaction

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.transaction/README.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.transaction/README.md
@@ -62,7 +62,7 @@ ValueTransfer {
 caver.transaction.getTransactionByHash('0x{transaction hash}')
 ```
 
-Querys transaction from Klaytn and converts to a caver transaction instance.
+Queries a transaction from Klaytn and converts to a caver transaction instance.
 
 **NOTE** `caver.transaction.getTransactionByHash` is supported since caver-js [v1.6.3](https://www.npmjs.com/package/caver-js/v/1.6.3).
 
@@ -107,7 +107,7 @@ LegacyTransaction {
 caver.transaction.recoverPublicKeys('0x{RLP-encoded transaction}')
 ```
 
-Recovers the public key strings from `signatures` field.
+Recovers the public key strings from `signatures` field of the given transaction.
 
 **NOTE** `caver.transaction.recoverPublicKeys` is supported since caver-js [v1.6.3](https://www.npmjs.com/package/caver-js/v/1.6.3).
 
@@ -140,7 +140,7 @@ Recovers the public key strings from `signatures` field.
 caver.transaction.recoverFeePayerPublicKeys('0x{RLP-encoded transaction}')
 ```
 
-Recovers the public key strings from `feePayerSignatures` field.
+Recovers the public key strings from `feePayerSignatures` field of the given transaction.
 
 **NOTE** `caver.transaction.recoverFeePayerPublicKeys` is supported since caver-js [v1.6.3](https://www.npmjs.com/package/caver-js/v/1.6.3).
 
@@ -148,7 +148,7 @@ Recovers the public key strings from `feePayerSignatures` field.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| rawTx | string | The RLP-encoded transaction string to recover public keys from `feePayerSignatures`. To recover fee payer's public keys, transaction should be fee-delegated with the `feePayerSignatures` variable inside. |
+| rawTx | string | The RLP-encoded transaction string to recover public keys from `feePayerSignatures`. To recover fee payer's public keys, the transaction should be a fee-delegated transaction with the `feePayerSignatures` field inside. |
 
 **Return Value**
 


### PR DESCRIPTION
`caver.transaction` 패키지에 새롭게 추가된 함수들에 대한 문서입니다.

`getTransactionByHash`는 Klay RPC Call을 사용해서 Klaytn으로부터 트랜잭션 객체를 받아와 Caver에서 제공하는 트랜잭션 인스턴스로 변환하여 리턴하는 함수입니다.

`caver.transaction.recoverPublicKeys` 와 `caver.transaction.recoverFeePayerPublicKeys` 는 각각 트랜잭션 내부의 `signatures`와 `feePayerSignatures` 필드로부터 pubilc key를 recover하는 함수입니다. 파라미터로는 RLP-encoded transaction string을 받습니다.

`tx.recoverPublicKeys` 와 `tx.recoverFeePayerPublicKeys`도 기능은 위와 동일하지만, 트래잭션의 메소드로 제공되어 따로 파라미터 없이 바로 public keys를 recover할 수 있습니다.