### PR TITLE
Added new functions in caver.utils

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.utils.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.utils.md
@@ -1673,7 +1673,7 @@ Recovers the Klaytn address that was used to sign the given data.
 '0xe8b3a6ef12f9506e1df9fd445f9bb4488a482122'
 ```
 
-## recoverPublicKey <a id="recoverpublicKey"></a>
+## recoverPublicKey <a id="recoverpublickey"></a>
 
 ```javascript
 caver.utils.recoverPublicKey(message, signature [, isHashed])


### PR DESCRIPTION
`caver.utils` 패키지에서 새롭게 제공되는 함수들입니다.

`caver.utils.recoverPublicKey` 는 message에 서명한 서명값으로부터 public key를 recover해주는 함수입니다.
`caver.utils.publicKeyToAddress`는 public key 에서 파생된 address를 리턴하는 함수입니다.
`caver.utils.decodeSignature` 는 'R(32 byte) + S(32 byte) + V(1byte)' 로 구성된 signature string을 v, r, s 데이터가 담긴 SignatureData로 변환하여 리턴해주는 함수입니다.