### PR TITLE
Fixed not-working code snippet

### DIFF
--- a/docs/bapp/sdk/caver-java/getting-started.md
+++ b/docs/bapp/sdk/caver-java/getting-started.md
@@ -322,7 +322,7 @@ SingleKeyring decrypt = (SingleKeyring)caver.wallet.keyring.decrypt(keyStoreJson
 System.out.println("Decrypted address : " + decrypt.getAddress());
 System.out.println("Decrypted key : " + decrypt.getKey().getPrivateKey());
 
-SingleKeyring addedKeyring = (SingleKeyring) caver.wallet.add(decrypt);
+SingleKeyring addedKeyring = (SingleKeyring)caver.wallet.add(decrypt);
 System.out.println("address : " + addedKeyring.getAddress());
 System.out.println("key : " + addedKeyring.getKey().getPrivateKey());
 ```


### PR DESCRIPTION
1> `SingleKeyring.getKey()` method returns PrivateKey class instance.
So we should use `PrivateKey.getPrivateKey()` method to get actual private key string.

2> `AbstractKeyring` class does not have `getKey()` method.
So we should convert it to SingleKeyring and use `SingleKeyring.getKey().getPrivateKey()` to get actual private key string.