### PR TITLE
Update hdwallet-klaytn usage according to the new release

### DIFF
--- a/docs/toolkit/truffle.md
+++ b/docs/toolkit/truffle.md
@@ -24,7 +24,7 @@ truffle-hdwallet-provider-klaytn is a JavaScript HD wallet provider forked from 
 Install as the following:
 
 ```text
-$ nvm use 10 # for node v7, v8, v10
+$ nvm use 10
 $ yarn install truffle-hdwallet-provider-klaytn@1.0.18
 ```
 


### PR DESCRIPTION
HDwallet 릴리즈에 대한 대한 내용 업데이트합니다~

v1.0.18 : https://github.com/klaytn/truffle-hdwallet-provider-klaytn/tree/f0953b55c5d6539c22cf8adf992a97795473bf42
v1.4.1 : https://github.com/klaytn/truffle-hdwallet-provider-klaytn/pull/5


merge는 릴리즈 되면 할게요~