### PR TITLE
[API] Remove unused api writeTroughCaching

### DIFF
--- a/docs/bapp/json-rpc/api-references/klay.md
+++ b/docs/bapp/json-rpc/api-references/klay.md
@@ -69,7 +69,6 @@ The list below enumerates the API functions that are currently supported in Klay
 - [klay_isSenderTxHashIndexingEnabled](./klay/config.md#klay_issendertxhashindexingenabled)
 - [klay_protocolVersion](./klay/config.md#klay_protocolversion)
 - [klay_rewardbase](./klay/config.md#klay_rewardbase)
-- [klay_writeThroughCaching](./klay/config.md#klay_writethroughcaching)
 
 
 ### [Filter](./klay/filter.md) <a id="filter"></a>

--- a/docs/bapp/json-rpc/api-references/klay/config.md
+++ b/docs/bapp/json-rpc/api-references/klay/config.md
@@ -244,32 +244,3 @@ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay
 }
 ```
 
-
-## klay_writeThroughCaching <a id="klay_writethroughcaching"></a>
-
-Returns `true` if the node is using write through caching. If enabled, block bodies and receipts are cached when they are written to persistent storage. It is `false` by default.
-
-**Parameters**
-
-None
-
-**Return Value**
-
-| Type     | Description                                           |
-| -------- | ----------------------------------------------------- |
-| Boolean | `true` means the node is using write through caching. |
-
-**Example**
-
-```shell
-// Request
-curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay_writeThroughCaching","id":1}' http://localhost:8551
-
-// Result
-{
-    "jsonrpc":"2.0",
-    "id":1,
-    "result":false
-}
-```
-

--- a/docs/bapp/sdk/caver-js/api-references/caver.rpc/README.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.rpc/README.md
@@ -79,7 +79,6 @@ The `caver.rpc.klay` allows you to interact with the Klaytn nodes. The list belo
 - [isSenderTxHashIndexingEnabled](./klay.md#caver-rpc-klay-issendertxhashindexingenabled)
 - [getProtocolVersion](./klay.md#caver-rpc-klay-getprotocolversion)
 - [getRewardbase](./klay.md#caver-rpc-klay-getrewardbase)
-- [isWriteThroughCaching](./klay.md#caver-rpc-klay-iswritethroughcaching)
 
 ### [Filter](./klay.md#caver-rpc-klay-getfilterchanges) <a id="filter"></a>
 - [getFilterChanges](./klay.md#caver-rpc-klay-getfilterchanges)

--- a/docs/bapp/sdk/caver-js/api-references/caver.rpc/klay.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.rpc/klay.md
@@ -2321,35 +2321,6 @@ Returns the rewardbase of the current node. Rewardbase is the address of the acc
 0xa9b3a93b2a9fa3fdcc31addd240b04bf8db3414c
 ```
 
-## caver.rpc.klay.isWriteThroughCaching <a id="caver-rpc-klay-iswritethroughcaching"></a>
-
-```javascript
-caver.rpc.klay.isWriteThroughCaching([callback])
-```
-
-Returns true if the node is using writeThroughCaching.
-
-**Parameters**
-
-| Name | Type | Description |
-| --- | --- | --- |
-| callback | function | (optional) Optional callback, returns an error object as the first parameter and the result as the second. |
-
-**Return Value**
-
-`Promise` returns `boolean`
-
-| Type | Description |
-| --- | --- |
-| boolean | true means the node is using write-through caching. |
-
-**Example**
-
-```javascript
-> caver.rpc.klay.isWriteThroughCaching().then(console.log)
-false
-```
-
 ## caver.rpc.klay.getFilterChanges <a id="caver-rpc-klay-getfilterchanges"></a>
 
 ```javascript

--- a/docs/bapp/sdk/caver-js/v1.4.1/api-references/caver.klay.md
+++ b/docs/bapp/sdk/caver-js/v1.4.1/api-references/caver.klay.md
@@ -81,7 +81,6 @@ enumerates the API functions that are currently supported in `caver-js`.
 - [isSenderTxHashIndexingEnabled](./caver.klay/config.md#issendertxhashindexingenabled)
 - [isParallelDBWrite](./caver.klay/config.md#isparalleldbwrite)
 - [rewardbase](./caver.klay/config.md#rewardbase)
-- [writeThroughCaching](./caver.klay/config.md#writethroughcaching)
 
 
 ## [Filter](./caver.klay/filter.md) <a id="filter"></a>

--- a/docs/bapp/sdk/caver-js/v1.4.1/api-references/caver.klay/config.md
+++ b/docs/bapp/sdk/caver-js/v1.4.1/api-references/caver.klay/config.md
@@ -207,27 +207,3 @@ Returns the rewardbase of the current node. Rewardbase is the address of the acc
 > caver.klay.rewardbase().then(console.log);
 0xed9d108be2a9a7ea5f180ace80f31b66ea107283
 ```
-
-## writeThroughCaching <a id="writethroughcaching"></a>
-
-```javascript
-caver.klay.writeThroughCaching([callback])
-```
-Returns `true` if the node is using write-through caching. If enabled, block bodies and receipts are cached to increase the read performance when they are written to persistent storage. It is `false` by default.
-
-**Parameters**
-
-| Name | Type | Description |
-| --- | --- | --- |
-| callback | Function | (optional) Optional callback, returns an error object as the first parameter and the result as the second. |
-
-**Return Value**
-
-`Promise` returns `Boolean` - `true` means the node is using write through caching.
-
-**Example**
-
-```javascript
-> caver.klay.writeThroughCaching().then(console.log);
-false
-```


### PR DESCRIPTION
API 문서 전체를 한번 살피며 불필요한 것 제거 및 없는 API 추가 등 정리했습니다.
그런데 [PR](https://github.com/ground-x/klaytn-docs/pull/289) 이 한 번에 리뷰 받기에 너무 크기도 하고,
반영될 Klaytn 버전 확인이 필요해서, 나눠서 올릴 예정입니다.

이 PR은 이제는 쓰이지 않는 api를 문서에서 제거하는 PR 입니다.

+ 전에 듣기로 Klaytn release 버전별 API 문서 나눠서 merge 하는 것으로 들었었는데, 
 현재는 따로 없는 것 같네요. 그럼 그냥 master로 merge 해도 될까요?