### PR TITLE
[API] Add net-version api docs

### DIFF
--- a/docs/bapp/json-rpc/api-references/network.md
+++ b/docs/bapp/json-rpc/api-references/network.md
@@ -121,3 +121,30 @@ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_
     "result": {"en":3,"pn":2,"total":5}
 }
 ```
+
+## net_version <a id="net_version"></a>
+
+Return the current klaytn protocol version.
+
+**Parameters**
+
+None
+
+**Return Value**
+
+| Type | Description |
+| --- | --- |
+| QUANTITY | The integer of the klaytn protocol version.<br> - `"1001"`: Klaytn Baobab testnet.<br> - `"8217"`: Klaytn Cypress mainnet.|
+
+**Example**
+
+```shell
+// Request
+curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"net_version","params":[],"id":67}' http://localhost:8551
+// Result
+{
+    "jsonrpc":"2.0",
+    "id":67,
+    "result":"1001"
+}
+```


### PR DESCRIPTION
API 문서 전체를 한번 살피며 불필요한 것 제거 및 없는 API 추가 등 정리했습니다.
그런데 [PR](https://github.com/ground-x/klaytn-docs/pull/289) 이 한 번에 리뷰 받기에 너무 크기도 하고,
반영될 Klaytn 버전 확인이 필요해서, 나눠서 올릴 예정입니다.

이 PR은 net-version API에 대한 docs를 추가한 내용입니다.

이 PR은 v1.7.0이 아닌 기존 버전에도 있는 API여서 master로 base 잡겠습니다.