### PR TITLE
[Command] Add dumpgenesis command docs

### DIFF
--- a/docs/node/endpoint-node/ken-cli-commands.md
+++ b/docs/node/endpoint-node/ken-cli-commands.md
@@ -17,7 +17,7 @@ COMMANDS:
    attach      Start an interactive JavaScript environment (connect to node)
    console     Start an interactive JavaScript environment
    dumpconfig  Show configuration values
-   dumpgenesis Dump genesis block JSON configuration to stdout
+   dumpgenesis Dump genesis block JSON configuration to stdout (This command is supoported from Klaytn v1.7.0.)
    init        Bootstrap and initialize a new genesis block
    version     Show version number
    help, h     Shows a list of commands or help for one command


### PR DESCRIPTION
이 PR은 [dumpgenesis command](https://github.com/klaytn/klaytn/pull/992)에 대한 docs를 추가한 내용입니다.

이 PR은 v1.7.0에서 추가될 내용이여서 v1.7.0을 base로 하겠습니다.