### PR TITLE
Removed unsupoorted rpc call

### DIFF
--- a/docs/bapp/sdk/caver-js/api-references/caver.rpc/klay.md
+++ b/docs/bapp/sdk/caver-js/api-references/caver.rpc/klay.md
@@ -2321,35 +2321,6 @@ Returns the rewardbase of the current node. Rewardbase is the address of the acc
 0xa9b3a93b2a9fa3fdcc31addd240b04bf8db3414c
 ```
 
-## caver.rpc.klay.isWriteThroughCaching <a id="caver-rpc-klay-iswritethroughcaching"></a>
-
-```javascript
-caver.rpc.klay.isWriteThroughCaching([callback])
-```
-
-Returns true if the node is using writeThroughCaching.
-
-**Parameters**
-
-| Name | Type | Description |
-| --- | --- | --- |
-| callback | function | (optional) Optional callback, returns an error object as the first parameter and the result as the second. |
-
-**Return Value**
-
-`Promise` returns `boolean`
-
-| Type | Description |
-| --- | --- |
-| boolean | true means the node is using write-through caching. |
-
-**Example**
-
-```javascript
-> caver.rpc.klay.isWriteThroughCaching().then(console.log)
-false
-```
-
 ## caver.rpc.klay.getFilterChanges <a id="caver-rpc-klay-getfilterchanges"></a>
 
 ```javascript


### PR DESCRIPTION
Klaytn에서 더이상 klay_writeThroughCaching rpc call을 제공하지 않아 문서에서 내용을 제거합니다.

참고 슬랙 https://ground-x.slack.com/archives/CHY07NXHS/p1600910666005300?thread_ts=1600852263.004500&cid=CHY07NXHS