### PR TITLE
[API] Add api error codes docs

### DIFF
--- a/docs/bapp/json-rpc/api-references/api-error-codes.md
+++ b/docs/bapp/json-rpc/api-references/api-error-codes.md
@@ -1,0 +1,59 @@
+---
+description: >-
+APIs error codes 
+---
+
+# API Error Codes <a id="api-error-codes"></a>
+
+Klaytn provides an `error` field in the API response to give developers more information about the reason for the failed API execution. This field exists only if the API execution fails. This field contains `error code` and `error message`.
+
+Example Response
+```
+{
+ "jsonrpc":"2.0",
+ "id":83,
+ "error":{
+    "code":-32602,
+    "message":"invalid argument 0: hex string without 0x prefix"
+ }
+}
+```
+
+---
+HTTP Errors
+> **NOTE**
+>
+> Only HTTP errors that are explicitly returned on Klaytn are listed. Please refer to [**FastHTTP repository**](https://github.com/valyala/fasthttp/blob/5d73da31aed12047d2625e86bf405a0cd1f77f2b/status.go) for all status codes.
+
+| Status Code | Error | Message Example |
+| :---   | :--- | :--- |
+| 403 | StatusForbidden | "invalid host specified" |
+| 404 | StatusNotFound | "404 page not found" |
+| 405 | StatusMethodNotAllowed | "method not allowed" |
+| 413 | StatusRequestEntityTooLarge | "content length too large n > 524288" |
+| 415 | StatusUnsupportedMediaType | "invalid content type, only application/json is supported" |
+
+---
+
+Standard JSON-RPC Errors
+
+> **NOTE**
+>
+> Although there are various types of errors for each status code, only one of each has been written for the purpose of brevity.
+
+| Error Code | Error | Message Example |
+| :---   | :--- | :--- |
+| -32000 | WSRPCNotRunningError |  "WebSocket RPC not running" |
+|        | InvalidNodeIdError |  "invalid kni: invalid node ID (wrong length, want 128 hex chars)" |
+|        | BlockNotFoundError |  "block #1 not found" |
+|        | BlockNotExistError |  "the block does not exist (block number: 1)" |
+|        | BlockDoesNotExistError |  "the block does not exist (block hash: 0xf...f)" |
+|        | UnknownAccountError |  "unknown account" |
+|        | TransactionNotFoundError |  "transaction 0xf...f not found" |
+|        | ShutDownError |  "server is shutting down" |
+| -32600 | InvalidRequestError | "server requests exceed the limit" |
+| -32601 | MethodNotFoundError | "The method does not exist/is not available" |
+| -32602 | InvalidParamsError  | "missing value for required argument 0" |
+|        |                     | "invalid argument 0: hex string without 0x prefix" |
+|        |                     | "invalid argument 0: json: cannot unmarshal string into Go value of type uint64" |
+| -32700 | InvalidMessageError | "unexpected end of JSON input" |


### PR DESCRIPTION
API Error code가 필요하다는 요구사항([slack](https://ground-x.slack.com/archives/C02B8M2CYAK/p1630030416011300))이 있어서 간단히 추가했습니다.
현재 ethereum fork 당시와 비교하여 error code는 크게 변하지 않았습니다.

에러 발생시, InvalidParamError(-32602)를 제외하면 거의 대부분 -32000으로 응답하고 있습니다. 
-32000 error의 경우는 error 종류가 너무 많아서 대표적인 에러만 몇 가지 적었습니다.

errorCode는 5개고 나머지는 message로 분리되는 형식이라 
사용자한테 도움이 되는 문서가 될지 확신이 없네요.
어떻게 생각하시는지 궁금합니다.
자세한 내용은 [Jira 티켓](https://groundx.atlassian.net/browse/KLT-1185) 참고해주시면 감사하겠습니다.

그 외에 질문
+ MD에서 셀병합이 안되는 것 같은데, html로 변환해서 행병합 시켜서 올려도 괜찮을까요?
+ 통상적인 400대 HTTP error 발생 가능성이 있는데, 이 부분을 포함할 필요는 없다고 생각하여 제외했습니다. 혹시 필요할까요?