### PR TITLE
Fix connecting-remix docs link url

### DIFF
--- a/docs/bapp/tutorials/connecting-remix.md
+++ b/docs/bapp/tutorials/connecting-remix.md
@@ -48,7 +48,7 @@ Remix is a browser-based IDE (Integrated Development Environment) for developing
 
 ## Case 2. Connecting Klaytn - Remix using MetaMask <a id="connecting-klaytn-remix-using-metamask"></a>
 
-* Connect Klaytn with MetaMask by referring to the [**Connecting to MetaMask**](https://groundx.atlassian.net/wiki/spaces/~59728130/pages/1880752196/Klaytn+Docs+-+Metamast+Remix).
+* Connect Klaytn with MetaMask by referring to the [**Connecting to MetaMask**](https://docs.klaytn.com/bapp/tutorials/connecting-metamask).
 * Select [Injected Web3] on the Remix Environment menu.
 
 ![Injected Web3](./img/remix-environment-injectedWeb3.png)


### PR DESCRIPTION
제가 전에 작업한 Connecting remix문서에서 
link를 제대로 확인하지 못해서 metamask 연결 docs가 아닌
metamask 연결 tutorial wiki의 링크가 올라가 있었네요.
수정 PR 올립니다!