### PR TITLE
Remove chainDB related APIs from Klaytn debug API list

### DIFF
--- a/docs/bapp/json-rpc/api-references/debug.md
+++ b/docs/bapp/json-rpc/api-references/debug.md
@@ -87,9 +87,3 @@ The namespace `debug` gives you access to several non-standard RPC methods, whic
 - [debug_stopWarmUp](./debug/blockchain.md#debug_stopwarmup)
 - [debug_startCollectingTrieStats](./debug/blockchain.md#debug_startCollectingTrieStats)
 
-
-## [Debug ChainDB](./debug/chaindb.md) <a id="debug-chaindb"></a>
-
-- [debug_chaindbProperty](./debug/chaindb.md#debug_chaindbproperty)
-- [debug_chaindbCompact](./debug/chaindb.md#debug_chaindbcompact)
-


### PR DESCRIPTION
- 삭제된 리스트는 https://github.com/ground-x/klaytn-docs/pull/308 에서 본문(chaindb.md)없이 추가되었습니다. 
- 해당 API들은 현재 정상적으로 실행되지 않기에 리스트에서 제거합니다. 