### PR TITLE
revert pending block support

### DIFF
--- a/docs/bapp/json-rpc/api-references/debug/blockchain.md
+++ b/docs/bapp/json-rpc/api-references/debug/blockchain.md
@@ -24,7 +24,7 @@ trie node' error.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| block number or hash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](../klay/block.md#the-default-block-parameter), or block hash.|
+| block number or hash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](../klay/block.md#the-default-block-parameter), or block hash.|
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only hex string type is available.
@@ -127,7 +127,7 @@ References: [RLP](https://github.com/ethereum/wiki/wiki/RLP)
 
 | Name | Type | Description |
 | --- | --- | --- |
-| block number or hash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](../klay/block.md#the-default-block-parameter), or block hash.|
+| block number or hash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](../klay/block.md#the-default-block-parameter), or block hash.|
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer type is available.
@@ -316,7 +316,7 @@ Retrieves a block and returns its pretty printed form.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| block number or hash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](../klay/block.md#the-default-block-parameter), or block hash.|
+| block number or hash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](../klay/block.md#the-default-block-parameter), or block hash.|
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer type is available.

--- a/docs/bapp/json-rpc/api-references/governance.md
+++ b/docs/bapp/json-rpc/api-references/governance.md
@@ -274,7 +274,7 @@ The `itemsAt` returns governance items at specific block. It is the result of pr
 
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
-| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](klay/block.md#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](klay/block.md#the-default-block-parameter). |
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.

--- a/docs/bapp/json-rpc/api-references/klay/account.md
+++ b/docs/bapp/json-rpc/api-references/klay/account.md
@@ -7,7 +7,7 @@ Returns `true` if the account associated with the address is created. It returns
 | Name | Type | Description |
 | --- | --- | --- |
 | account | 20-byte DATA | Address |
-| block number or hash | QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
+| block number or hash | QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.
@@ -231,7 +231,7 @@ Returns the account information of a given address. There are two different acco
 |   Name  | Type          | Description                                                  |
 | ------- | ------------- | ------------------------------------------------------------ |
 | address | 20-byte DATA  | Address                                                      |
-| block number or hash    | QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
+| block number or hash    | QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.
@@ -306,7 +306,7 @@ Returns the account key of the Externally Owned Account (EOA) of a given address
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
 | 20-byte DATA | Address                                                      |
-| QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash.|
+| QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash.|
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.
@@ -394,7 +394,7 @@ Returns the balance of the account of given address.
 | Name | Type           | Description                                                  |
 | ---- | -------------- | ------------------------------------------------------------ |
 | address | 20-byte DATA | Address to check for balance.                               |
-| block number or hash | QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
+| block number or hash | QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.
@@ -429,7 +429,7 @@ Returns code at a given address.
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
 | 20-byte DATA | Address                                                      |
-| QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
+| QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.
@@ -465,7 +465,7 @@ Returns the number of transactions *sent* from an address.
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
 | 20-byte DATA | Address                                                      |
-| QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash.|
+| QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash.|
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.
@@ -503,7 +503,7 @@ Returns `true` if an input account has a non-empty codeHash at the time of a spe
 | Name | Type | Description |
 | --- | --- | --- |
 | account | 20-byte DATA | Address |
-| block number or hash | QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
+| block number or hash | QUANTITY &#124; TAG &#124; HASH | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash. |
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.

--- a/docs/bapp/json-rpc/api-references/klay/block.md
+++ b/docs/bapp/json-rpc/api-references/klay/block.md
@@ -8,6 +8,7 @@ The following options are possible for the `defaultBlock` parameter:
 - `HEX String` - an integer block number
 - `String "earliest"` for the earliest/genesis block
 - `String "latest"` - for the latest mined block
+- `String "pending"` - for the pending state/transactions
 
 
 ## klay_blockNumber <a id="klay_blocknumber"></a>
@@ -50,7 +51,7 @@ This API works only on RPC call, not on JavaScript console.
 
 | Type | Description |
 | --- | --- |
-| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](#the-default-block-parameter). |
 
 **Return Value**
 
@@ -156,7 +157,7 @@ This API works only on RPC call, not on JavaScript console.
 
 | Type | Description |
 | --- | --- |
-| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](#the-default-block-parameter). |
 | Boolean | If `true` it returns the full transaction objects, if `false` only the hashes of the transactions. |
 
 {% hint style="success" %} 
@@ -342,7 +343,7 @@ Returns the number of transactions in a block matching the given block number.
 
 | Type          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
-| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](block.md#the-default-block-parameter). |
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.
@@ -772,7 +773,7 @@ Returns the value from a storage position at a given address.
 | --- | --- |
 | 20-byte DATA | Address of the storage. |
 | QUANTITY | Integer of the position in the storage. |
-| QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter), or block hash.|
+| QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](block.md#the-default-block-parameter), or block hash.|
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.

--- a/docs/bapp/json-rpc/api-references/klay/filter.md
+++ b/docs/bapp/json-rpc/api-references/klay/filter.md
@@ -116,8 +116,8 @@ The execution of this API can be limited by two node configurations to manage re
 
 | Name | Type | Description |
 | --- | --- | --- |
-| fromBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
-| toBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
+| fromBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](block.md#the-default-block-parameter). |
+| toBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](block.md#the-default-block-parameter). |
 | address | 20-byte DATA &#124; Array | (optional) Contract address or a list of addresses from which logs should originate. |
 | topics | Array of DATA | (optional) Array of 32-byte DATA topics. Topics are order-dependent. Each topic can also be an array of DATA with “or” options. |
 | blockHash | 32-byte DATA | (optional) A filter option that restricts the logs returned to the single block with the 32-byte hash blockHash. Using blockHash is equivalent to fromBlock = toBlock = the block number with hash blockHash. If blockHash is present in in the filter criteria, then neither fromBlock nor toBlock are allowed. |
@@ -298,8 +298,8 @@ Topics are order-dependent. A transaction with a log with topics `[A, B]` will b
 
 | Name | Type | Description |
 | --- | --- | --- |
-| fromBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
-| toBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](block.md#the-default-block-parameter). |
+| fromBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](block.md#the-default-block-parameter). |
+| toBlock | QUANTITY &#124; TAG | (optional, default: `"latest"`) Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](block.md#the-default-block-parameter). |
 | address | 20-byte DATA &#124; Array | (optional) Contract address or a list of addresses from which logs should originate. |
 | topics | Array of DATA | (optional) Array of 32-byte DATA topics. Topics are order-dependent. Each topic can also be an array of DATA with "or" options. |
 

--- a/docs/bapp/json-rpc/api-references/klay/transaction.md
+++ b/docs/bapp/json-rpc/api-references/klay/transaction.md
@@ -7,7 +7,7 @@ Executes a new message call immediately without creating a transaction on the bl
 | Name | Type | Description |
 | --- | --- | --- |
 | callObject | Object | The transaction call object.  See the next table for the object's properties. |
-| blockNumberOrHash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash.|
+| blockNumberOrHash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](./block.md#the-default-block-parameter), or block hash.|
 
 {% hint style="success" %} 
 NOTE: In versions earlier than Klaytn v1.7.0, only integer block number, the string `"earliest"` and `"latest"` are available.
@@ -178,7 +178,7 @@ This API works only on RPC call, not on JavaScript console.
 
 | Type | Description |
 | --- | --- |
-| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"` or `"latest"` as in the [default block parameter](./block.md#the-default-block-parameter). |
+| QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"`  as in the [default block parameter](./block.md#the-default-block-parameter). |
 | QUANTITY | The transaction index position. |
 
 {% hint style="success" %} 


### PR DESCRIPTION
이전에 https://github.com/ground-x/klaytn-docs/pull/231 PR에서 pending block 개념을 api에서 지웠었는데
이번에 이더리움 호환성을 맞추기 위해 다시 revert 시켰습니다. 이에 대해 docs를 수정하여 PR을 다시 올립니다.

- pending 삭제한 API에서 pending revert
