### PR TITLE
Revert #335 to resolve gitbook sync issues

### DIFF
--- a/docs/smart-contract/porting-ethereum-contract.md
+++ b/docs/smart-contract/porting-ethereum-contract.md
@@ -2,11 +2,7 @@
 
 In most cases, you can use Ethereum contracts on Klaytn without any modification.
 However, be aware of the following two issues.  
-{% hint style="success" %}
-NOTE: In case of Baobab network, protocol upgrade was enabled from block number `#75373312`.
-Cypress mainnet will be subject to the same protocol upgrade in the next version.
 
-{% endhint %}
 ## Solidity Support <a id="solidity-support"></a>
 
 Klaytn is currently compatible with **Istanbul** Ethereum Virtual Machine (EVM) version. 


### PR DESCRIPTION
Klaytn v1.7.1 문서 중 해당 파일에서 수정한 내용이 영문에 반영되지 않았고, 국문/영문 모두 porting-ethereum-contract.md 파일로 인해 GitBook sync err가 발생하였습니다. 현재 두 언어 모두 최신 버전이 노출되지 않아 우선 에러의 원인인 파일만 롤백 후 에러가 해결되는지 확인해볼 예정입니다.

cc @hqjang-pepper @yoomee1313 