### PR TITLE
Revise porting ethereum contract

### DIFF
--- a/docs/smart-contract/porting-ethereum-contract.md
+++ b/docs/smart-contract/porting-ethereum-contract.md
@@ -13,9 +13,9 @@ Cypress mainnet has not enabled the protocol upgrade yet, but soon, it will be s
 
 Backward compatibility is not guaranteed with other EVM versions on Klaytn.
 Thus, it is highly recommended compiling Solidity code with the correct target option according to the protocol upgrade status.
-* baobab: istanbul
-* cypress: constantinople
-* other(private/service chain): determined according to the protocol upgrade status
+* Baobab: --evm-version istanbul
+* Cypress: --evm-version constantinople
+* Others(private/service chain): determined according to the protocol upgrade status
 
 Please refer to [how to set the EVM version of solc](https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target).
 


### PR DESCRIPTION
다음 두 가지 수정이 추가되었습니다.
* baobab, cypress 두 케이스에 대하여 나누어서 EVM compatibility 및 solidity target option 표현.
* baobab, cypress에서 protocol upgrade이 활성화됨에 따른 EVM compatibility 변경사항 설명 추가.