### PR TITLE
caver.ipfs.add(). Buffer as parameter

### DIFF
--- a/docs/dapp/sdk/caver-js/api-references/caver.ipfs.md
+++ b/docs/dapp/sdk/caver-js/api-references/caver.ipfs.md
@@ -66,7 +66,7 @@ If the path of a file is passed, the contents of the file are loaded from the pa
 Qmd9thymMS6mejhEDZfwXPowSDunzgma9ex4ezpCSRZGwC
 
 // Adds a file with Buffer containing the contents of the file.
-> caver.ipfs.add(Buffer.from('test data'))
+> caver.ipfs.add(Buffer.from('test data').buffer)
 QmWmsL95CYvci8JiortAMhezezr8BhAwAVohVUSJBcZcBL
 ```
 


### PR DESCRIPTION
## Proposed changes

When we use caver.ipfs.add(string | Buffer | ArrayBuffer) and want to pass file contents as buffer,  please use this pattern :     caver.ipfs.add( Buffer.from('xxxxx').buffer )

## Types of changes

Please put an x in the boxes related to your change.

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn-docs/blob/master/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn-docs)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- None

## Further comments

- None