### PR TITLE
[SC] Fix command for operator balance check

### DIFF
--- a/docs/node/service-chain/getting-started/value-transfer.md
+++ b/docs/node/service-chain/getting-started/value-transfer.md
@@ -42,9 +42,9 @@ True
 ```
 Check if the operator accounts have enough balance.
 ```
-> klay.getBalance(subbridge.childOperator)
+> subbridge.childOperatorBalance
 1e+21
-> klay.getBalance(subbridge.parentOperator)
+> subbridge.parentOperatorBalance
 1e+18
 ```
 


### PR DESCRIPTION
Fixed operator balance check command to use provided subbridge APIs `childOperatorBalance` and `parentOperatorBalance`.
In fact, the command `klay.getBalance(subbridge.parentOperator)` would never work, because that command has to be issued in the parent chain however the parent chain is unlikely to provide `subbridge` API namespace.

## Proposed changes

- Use `subbridge.parentOperatorBalance` instead of `klay.getBalance(subbridge.parentOperator)`
- Use `subbridge.childOperatorBalance` instead of `klay.getBalance(subbridge.childOperator)` in accordance with above change.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn-docs/blob/master/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn-docs)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Did not create an issue, because it seemed to be too minor to be a separate issue..