### PR TITLE
Removed RNs from the description of KLAY

### DIFF
--- a/docs/klaytn/design/klaytn-native-coin-klay.md
+++ b/docs/klaytn/design/klaytn-native-coin-klay.md
@@ -4,7 +4,7 @@
 
 KLAY is the main internal transferable cryptocurrency of Klaytn and is used to pay transaction fees when creating or executing smart contracts or when transferring KLAY.
 
-KLAY is a necessary element--a fuel--for operating the Klaytn distributed application platform. It is a form of payment made by the clients of the platform to the consensus nodes \(CNs\) executing the requested operations. To put it another way, KLAY is an incentive; it ensures that developers write high-quality applications \(wasteful code costs more\) and that the network remains healthy \(CNs and RNs are compensated for the resources they contribute\).
+KLAY is a necessary element--a fuel--for operating the Klaytn distributed application platform. It is a form of payment made by the clients of the platform to the consensus nodes \(CNs\) executing the requested operations. To put it another way, KLAY is an incentive; it ensures that developers write high-quality applications \(wasteful code costs more\) and that the network remains healthy \(CNs are compensated for the resources they contribute\).
 
 ## Units of KLAY <a id="units-of-klay"></a>
 


### PR DESCRIPTION
RNs are not part of Klaytn.

## Proposed changes

Updated the description of KLAY by removing the term RN, which is not part of Klaytn anymore.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn-docs/blob/master/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn-docs)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

N/A

## Further comments

N/A