### PR TITLE
Fix command argument ordering

### DIFF
--- a/docs/getting-started/account/creating-accounts.md
+++ b/docs/getting-started/account/creating-accounts.md
@@ -51,8 +51,8 @@ This imports an unencrypted private key from the given keyfile, creates a new ac
 ### ken <a id="ken-1"></a>
 
 ```bash
-$ ken account import <keyfile> --datadir <DATADIR>
-$ ken account import --password <passwordfile> <keyfile> --datadir <DATADIR>
+$ ken account import --datadir <datadir> <keyfile>
+$ ken account import --password <passwordfile> --datadir <datadir> <keyfile>
 ```
 
 ### JavaScript Console <a id="javascript-console-1"></a>

--- a/docs/installation-guide/deployment/service-chain/getting-started/4nodes-setup-guide.md
+++ b/docs/installation-guide/deployment/service-chain/getting-started/4nodes-setup-guide.md
@@ -68,11 +68,11 @@ x homi-XXXXX-amd64/bin/homi
 ```
 
 Go to the `bin` folder and execute `homi` with following options to generate the files.
-`homi setup local --cn-num 4 --test-num 1 --servicechain --chainID 1002 --p2p-port 22323 -o homi-output`
+`homi setup --gen-type local --cn-num 4 --test-num 1 --servicechain --chainID 1002 --p2p-port 22323 -o homi-output`
 Since Baobab's `chainID` is 1001, for convenience, the `chainID` of the ServiceChain constructed in this example is set to 1002. When operating a blockchain by launching an actual service, it is recommended to use it after registering a new chainID value at https://chainlist.defillama.com/ so that chainID does not overlap with other ServiceChains. The ServiceChain port is set to 22323, which is the default port.
 
 ```console
-$ ./homi setup local --cn-num 4 --test-num 1 --servicechain --chainID 1002 --p2p-port 22323 -o homi-output
+$ ./homi setup --gen-type local --cn-num 4 --test-num 1 --servicechain --chainID 1002 --p2p-port 22323 -o homi-output
 Created :  homi-output/keys/passwd1
 Created :  homi-output/keys/passwd2
 Created :  homi-output/keys/passwd3

--- a/docs/installation-guide/deployment/service-chain/getting-started/en-scn-connection.md
+++ b/docs/installation-guide/deployment/service-chain/getting-started/en-scn-connection.md
@@ -34,7 +34,7 @@ It will create the data folder storing the chain data and logs on your home dire
 You can change the data folder using the `--datadir` directive.
 
 ```
-EN-01$ ken --datadir ~/data init ~/genesis.json
+EN-01$ ken init --datadir ~/data ~/genesis.json
 ```
 
 ## Step 3: Configure the EN Node <a id="step-3-configure-the-en-node"></a>

--- a/docs/installation-guide/deployment/service-chain/getting-started/nested-sc.md
+++ b/docs/installation-guide/deployment/service-chain/getting-started/nested-sc.md
@@ -15,7 +15,7 @@ As when configuring ServiceChain L2, execute the `homi` command to create script
 
 
 ```console
-$ ./homi setup local --cn-num 4 --test-num 1 --servicechain --chainID 1003 --p2p-port 22323 -o homi-output
+$ ./homi setup --gen-type local --cn-num 4 --test-num 1 --servicechain --chainID 1003 --p2p-port 22323 -o homi-output
 Created :  homi-output/keys/passwd1
 Created :  homi-output/keys/passwd2
 Created :  homi-output/keys/passwd3

--- a/docs/installation-guide/deployment/service-chain/references/scn/configuration.md
+++ b/docs/installation-guide/deployment/service-chain/references/scn/configuration.md
@@ -15,7 +15,7 @@ In this tutorial, we will not always specify the full path to the command.
 
 First, you should create a genesis file and a nodekey file for your own service chain. You can create them using homi like below.
 ```bash
-$ homi setup local --cn-num 1 --servicechain -o ./homi-output
+$ homi setup --gen-type local --cn-num 1 --servicechain -o ./homi-output
 Created :  homi-output/keys/passwd1
 Created :  homi-output/scripts/genesis.json
 Created :  homi-output/keys/nodekey1

--- a/docs/operation-guide/klaytn-command.md
+++ b/docs/operation-guide/klaytn-command.md
@@ -50,10 +50,10 @@ $ sudo kcn attach klay.ipc
 
 ```jsx
 # execute the command below in the Klaytn DATA_DIR Path
-$ sudo kcn attach klay.ipc --exec API
+$ sudo kcn attach --exec <statement> klay.ipc
 
 e.g.
 # Check my dode address
-  $sudo kcn attach klay.ipc --exec governance.nodeAddress
-   "0xda23978e6e354fbf25dd87aaf1d1bb4ed112753f"
+$ sudo kcn attach --exec "governance.nodeAddress" klay.ipc
+"0xda23978e6e354fbf25dd87aaf1d1bb4ed112753f"
 ```


### PR DESCRIPTION
## Proposed changes

- Fix some command line examples
  - Since v1.11.0, position arguments must be placed at the end of the command

## Types of changes

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others

## Checklist

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn-docs/blob/master/CONTRIBUTING.md)
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn-docs)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

https://github.com/klaytn/klaytn/issues/1936
https://github.com/klaytn/klaytn/pull/1684