### PR TITLE
Update API change in v1.12.0

### DIFF
--- a/docs/dapp/json-rpc/api-references/admin.md
+++ b/docs/dapp/json-rpc/api-references/admin.md
@@ -77,6 +77,53 @@ $ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"ad
 "protocols":{"istanbul":{"network":1000,"difficulty":1,"genesis":"0x06806bd8b1e086dfb7098a289da07037a3af58e793d205d20f61c88eeea9351d","config":{"chainId":1000,"istanbul":{"epoch":30000,"policy":0,"sub":7},"isBFT":true,"unitPrice":25000000000,"deriveShaImpl":0},"head":"0x06806bd8b1e086dfb7098a289da07037a3af58e793d205d20f61c88eeea9351d"}}}}
 ```
 
+## admin_nodeConfig <a id="admin_nodeconfig"></a>
+
+The `nodeConfig` administrative property can be queried for all the configuration set for the running Klaytn node.
+
+| Client  | Method invocation                         |
+|:-------:|-------------------------------------------|
+| Console | `admin.nodeConfig`                          |
+| RPC     | `{"method": "admin_nodeConfig"}`            |
+
+**Parameters**
+
+None
+
+**Return Value**
+
+| Type | Description |
+| --- | --- |
+| JSON string | The node configuration. |
+
+**Example**
+
+Console
+```javascript
+> admin.nodeConfig
+{
+  AnchoringPeriod: 0,
+  AutoRestartFlag: false,
+  DBType: "LevelDB",
+  DaemonPathFlag: "/klaytn-docker-pkg/bin/kend",
+  DisableUnsafeDebug: false,
+
+  ...
+
+  TxResendCount: 1000,
+  TxResendInterval: 4,
+  TxResendUseLegacy: false,
+  WorkerDisable: false,
+  WsEndpoint: "0.0.0.0:8552"
+}
+```
+
+HTTP RPC
+
+```shell
+$ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"admin_nodeConfig","id":1}' https://public-en-baobab.klaytn.net
+{"jsonrpc":"2.0","id":1,"result":{"Genesis":null,"NetworkId":1001,"SyncMode":"full","NoPruning":false,"WorkerDisable":false,"DownloaderDisable":false,"FetcherDisable":false,"ParentOperatorAddr":null,"AnchoringPeriod":0,"SentChainTxsLimit":0,"OverwriteGenesis":false,"StartBlockNumber":0,"DBType":"LevelDB","SkipBcVersionCheck":false,"SingleDB":false,"NumStateTrieShards":4,"EnableDBPerfMetrics":true,"LevelDBCompression":0,"LevelDBBufferPool":true,"LevelDBCacheSize":768,"DynamoDBConfig":{"TableName":"","Region":"ap-northeast-2","Endpoint":"","S3Endpoint":"","IsProvisioned":false,"ReadCapacityUnits":10000,"WriteCapacityUnits":10000,"ReadOnly":false,"PerfCheck":false},"RocksDBConfig":{"Secondary":false,"DumpMallocStat":false,"DisableMetrics":false,"CacheSize":768,"CompressionType":"lz4","BottommostCompressionType":"zstd","FilterPolicy":"ribbon","MaxOpenFiles":1024,"CacheIndexAndFilter":false},"TrieCacheSize":512,"TrieTimeout":300000000000,"TrieBlockInterval":128,"TriesInMemory":128,"LivePruning":false,"LivePruningRetention":172800,"SenderTxHashIndexing":false,"ParallelDBWrite":true,"TrieNodeCacheConfig":{"CacheType":"LocalCache","NumFetcherPrefetchWorker":32,"UseSnapshotForPrefetch":false,"LocalCacheSizeMiB":1024,"FastCacheFileDir":"/home/ubuntu/klaytn/data/fastcache","FastCacheSavePeriod":0,"RedisEndpoints":null,"RedisClusterEnable":false,"RedisPublishBlockEnable":false,"RedisSubscribeBlockEnable":false},"SnapshotCacheSize":0,"SnapshotAsyncGen":false,"ServiceChainSigner":"0x0000000000000000000000000000000000000000","ExtraData":null,"GasPrice":25000000000,"Rewardbase":"0x0000000000000000000000000000000000000000","TxPool":{"NoLocals":false,"AllowLocalAnchorTx":false,"DenyRemoteTx":false,"Journal":"/home/ubuntu/klaytn/data/klay/transactions.rlp","JournalInterval":3600000000000,"PriceLimit":1,"PriceBump":10,"ExecSlotsAccount":4096,"ExecSlotsAll":4096,"NonExecSlotsAccount":4096,"NonExecSlotsAll":4096,"KeepLocals":false,"Lifetime":300000000000,"NoAccountCreation":false,"EnableSpamThrottlerAtRuntime":false},"GPO":{"Blocks":20,"Percentile":60,"MaxHeaderHistory":1024,"MaxBlockHistory":1024,"Default":null},"EnablePreimageRecording":false,"EnableInternalTxTracing":false,"EnableOpDebug":false,"Istanbul":{"Timeout":10000,"BlockPeriod":1,"ProposerPolicy":0,"Epoch":30000,"SubGroupSize":21},"DocRoot":"","WsEndpoint":"0.0.0.0:8652","TxResendInterval":4,"TxResendCount":1000,"TxResendUseLegacy":false,"NoAccountCreation":false,"IsPrivate":false,"AutoRestartFlag":false,"RestartTimeOutFlag":900000000000,"DaemonPathFlag":"/home/ubuntu/klaytn/bin/kend","RPCGasCap":null,"RPCEVMTimeout":5000000000,"RPCTxFeeCap":0,"DisableUnsafeDebug":false,"StateRegenerationTimeLimit":60000000000}}
+```
 
 ## admin_datadir <a id="admin_datadir"></a>
 

--- a/docs/dapp/json-rpc/api-references/debug/blockchain.md
+++ b/docs/dapp/json-rpc/api-references/debug/blockchain.md
@@ -350,8 +350,6 @@ $ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"de
 
 ## debug_setHead <a id="debug_sethead"></a>
 
-**`WARNING`**: This API is not yet implemented and always returns "not yet implemented API" error.
-
 Sets the current head of the local chain by block number.
 
 **NOTE**: This is a destructive action and may severely damage your chain.
@@ -367,7 +365,7 @@ Use with *extreme* caution.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| number | string | The block number in hexadecimal string. |
+| number | QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](#the-default-block-parameter). |
 
 **Return Value**
 

--- a/docs/dapp/json-rpc/api-references/debug/blockchain.md
+++ b/docs/dapp/json-rpc/api-references/debug/blockchain.md
@@ -14,7 +14,7 @@ accounts (including storage and code).
 numbers.  Retrieving older block state is restricted depending on the value set for the command-line
 option `--state.block-interval` (default: 128).  This means that the function
 performs the state retrieval against only the block numbers that are
-multiples of state.block-interval.  For example, when 
+multiples of state.block-interval.  For example, when
 state.block-interval is 128, this function returns the state for the
 block numbers "0x0", "0x80", "0x100", "0x180", and so on.  If the block
 number is not a multiple of state.block-interval, it returns 'missing
@@ -31,7 +31,7 @@ trie node' error.
 | --- | --- | --- |
 | block number or hash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](../klay/block.md#the-default-block-parameter), or block hash.|
 
-{% hint style="success" %} 
+{% hint style="success" %}
 NOTE: In versions earlier than Klaytn v1.7.0, only hex string type is available.
 {% endhint %}
 
@@ -134,7 +134,7 @@ References: [RLP](https://github.com/ethereum/wiki/wiki/RLP)
 | --- | --- | --- |
 | block number or hash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](../klay/block.md#the-default-block-parameter), or block hash.|
 
-{% hint style="success" %} 
+{% hint style="success" %}
 NOTE: In versions earlier than Klaytn v1.7.0, only integer type is available.
 {% endhint %}
 
@@ -323,7 +323,7 @@ Retrieves a block and returns its pretty printed form.
 | --- | --- | --- |
 | block number or hash | QUANTITY &#124; TAG &#124; HASH| Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](../klay/block.md#the-default-block-parameter), or block hash.|
 
-{% hint style="success" %} 
+{% hint style="success" %}
 NOTE: In versions earlier than Klaytn v1.7.0, only integer type is available.
 {% endhint %}
 
@@ -365,7 +365,7 @@ Use with *extreme* caution.
 
 | Name | Type | Description |
 | --- | --- | --- |
-| number | QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](#the-default-block-parameter). |
+| number | QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in the [default block parameter](../klay/block.md#the-default-block-parameter). |
 
 **Return Value**
 

--- a/docs/dapp/json-rpc/api-references/eth/block.md
+++ b/docs/dapp/json-rpc/api-references/eth/block.md
@@ -297,6 +297,52 @@ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_
 }
 ```
 
+## eth_getBlockReceipts <a id="eth_getblockreceipts"></a>
+
+Returns receipts included in a block.
+
+**Parameters**
+| Type | Description |
+| --- | --- |
+| Number &#124; 32-byte DATA &#124; TAG  | The block number or hash. Or the string `"earliest"`, `"latest"` or `"pending"` as in [default block parameter](#the-default-block-parameter). |
+
+**Return Value**
+
+Receipts included in a block.  If the target block contains no transaction, an
+empty array `[]` is returned.
+
+**Example**
+
+```shell
+// Request
+curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"eth_getBlockReceipts", "params":["0xb14e8716f732186f2c99bb7a215a7cb1ec40e91e8d83739bfb593ed4b9047aa1"],"id":1}' https://public-en-baobab.klaytn.net
+
+// Result
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "blockHash": "0xb14e8716f732186f2c99bb7a215a7cb1ec40e91e8d83739bfb593ed4b9047aa1",
+      "blockNumber": "0x85ef20d",
+      "contractAddress": null,
+      "cumulativeGasUsed": "0x23b6e",
+      "effectiveGasPrice": "0x5d21dba00",
+      "from": "0x60d690e4d5db4025f4781c6cf3bff8669500823c",
+      "gasUsed": "0x23b6e",
+      "logs": [
+        ...
+      ],
+      "logsBloom": "0x00000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000220000000400000000000000000000000000000000000002000000000010001000000000040000000000000000000000000000000000000000000000000000400000080000000100000000000000000000000000000000000000000000480000000000000000000000010000000001000000000000000000000000000000000000000000009000000000000000000000000000000000000000008000000000000000004000000000004000000000000000000000000000000000000000000000000000000000000000200",
+      "status": "0x1",
+      "to": "0x27e1255f2a0ea596992158a0bc838f43be34b99d",
+      "transactionHash": "0xafd15213b06144a85dd02adf88c32efb3d395e784f153c213a40b7ea25de1942",
+      "transactionIndex": "0x0",
+      "type": "0x0"
+    }
+  ]
+}
+```
 
 ## eth_getUncleByBlockHashAndIndex <a id="eth_getunclebyblockhashandindex"></a>
 

--- a/docs/dapp/json-rpc/api-references/eth/gas.md
+++ b/docs/dapp/json-rpc/api-references/eth/gas.md
@@ -161,8 +161,9 @@ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_
 
 Returns a suggestion for a gas tip cap for dynamic fee transaction in peb.
 
-**NOTE**: This API has different behavior from Ethereum's and
-returns a gas price of Klaytn instead of suggesting a gas price as in Ethereum.
+**NOTE**: This API has different behavior from Ethereum's.
+Before Magma hardfork, it returns a gas price of Klaytn instead of suggesting a gas price as in Ethereum.
+After Magma hardfork, it just returns 0.
 
 **Parameters**
 
@@ -183,7 +184,7 @@ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_
 // Result
 {
   "jsonrpc": "2.0",
-  "id":1)
+  "id": 1,
   "result": "0xAE9F7BCC00" // 250,000,000,000 peb = 250 ston (Gwei)
 }
 ```

--- a/docs/dapp/json-rpc/api-references/eth/misc.md
+++ b/docs/dapp/json-rpc/api-references/eth/misc.md
@@ -160,4 +160,43 @@ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_
 }
 ```
 
+## eth_createAccessList <a id="eth_createaccesslist"></a>
 
+This method creates an `accessList` based on a given `Transaction`.
+The `accessList` contains all storage slots and addresses read and written by the transaction, except for the sender account and the precompiles.
+This method uses the same transaction call object and `blockNumberOrTag` object as [`eth_call`](./transaction.md#eth_call).
+An accessList can be used to unstuck contracts that became inaccessible due to gas cost increases.
+Adding an `accessList` to your transaction does not necessary result in lower gas usage compared to a transaction without an access list.
+
+**Parameters**
+
+| Name             | Type                | Description                                                                                              |
+|------------------|---------------------|----------------------------------------------------------------------------------------------------------|
+| callObject       | Object              | The transaction call object. Refer to [`eth_call`](./transaction.md#eth_call) for the object's properties. |
+| blockNumberOrTag | QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in [default block parameter](./block.md#the-default-block-parameter). The block number is mandatory and defines the context (state) against which the specified transaction should be executed. |
+
+**Return Value**
+
+| Type      | Description                                                              |
+|-----------|--------------------------------------------------------------------------|
+| Object    | Returns list of addresses and storage keys used by the transaction, plus the gas consumed when the access list is added. |
+
+**Example**
+
+```shell
+// Request
+curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_createAccessList", "params": [{"from": "0x8cd02c6cbd8375b39b06577f8d50c51d86e8d5cd", "data": "0x608060806080608155"}, "latest"], "id":1}' http://localhost:8551
+
+// Result
+{
+  "jsonrpc": "2.0",
+  "id":1,
+  "result": {
+    "accessList": [{
+      "address": "0xa02457e5dfd32bda5fc7e1f1b008aa5979568150",
+      "storageKeys": ["0x0000000000000000000000000000000000000000000000000000000000000081"]
+    }],
+    "gasUsed": "0x128ee"
+  }
+}
+```

--- a/docs/dapp/json-rpc/api-references/klay/block.md
+++ b/docs/dapp/json-rpc/api-references/klay/block.md
@@ -283,12 +283,12 @@ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay
 
 ## klay_getBlockReceipts <a id="klay_getblockreceipts"></a>
 
-Returns receipts included in a block identified by block hash.
+Returns receipts included in a block.
 
 **Parameters**
 | Type | Description |
 | --- | --- |
-| 32-byte DATA  | Block hash |
+| Number &#124; 32-byte DATA &#124; TAG  | The block number or hash. Or the string `"earliest"`, `"latest"` or `"pending"` as in [default block parameter](#the-default-block-parameter). |
 
 **Return Value**
 
@@ -299,34 +299,32 @@ empty array `[]` is returned.
 
 ```shell
 // Request
-curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"klay_getBlockReceipts", "params":["0xdc762ed0274496e2a42278e2648d910d82468687b5415bb5eb058a96a0b93c30"],"id":73}' https://public-en-baobab.klaytn.net
+curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0", "method":"klay_getBlockReceipts", "params":["0xb14e8716f732186f2c99bb7a215a7cb1ec40e91e8d83739bfb593ed4b9047aa1"],"id":1}' https://public-en-baobab.klaytn.net
 
 // Result
 {
-  "jsonrpc":"2.0",
-  "id":73,
-  "result":[{
-    "blockHash":"0xdc762ed0274496e2a42278e2648d910d82468687b5415bb5eb058a96a0b93c30",
-    "blockNumber":"0x3ba38",
-    "contractAddress":null,
-    "effectiveGasPrice":"0x5d21dba00",
-    "from":"0x16b11cf9c2186a117b0da38315b42b1eaa03bbe5",
-    "gas":"0x30d40",
-    "gasPrice":"0xba43b7400",
-    "gasUsed":"0x1886c",
-    "logs":[],
-    "logsBloom":"0x00000000000000000000000000000000008000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000040000080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-    "nonce":"0x58e",
-    "senderTxHash":"0x234469b3d3222657c98904deaba7ec6613161ea9405275025f4784a4d9918af5",
-    "signatures":["0x7f6","0x50b2b0f95b8a6d7018369b1933d6cebb52ef119463d1840a6181d05bf8fc29d8","0x329630f88d9d06c5f1bd7644dbf6bd6b92e4ab0e3d47122972f8294c9289e7bb"],
-    "status":"0x1",
-    "to":"0xdbb98c72e9818ad2c93a09e35ad43ada0d4223f0",
-    "transactionHash":"0x234469b3d3222657c98904deaba7ec6613161ea9405275025f4784a4d9918af5",
-    "transactionIndex":"0x0",
-    "type":"TxTypeValueTransfer",
-    "typeInt":8,
-    "value":"0x21e19e0c9bab2400000"
-  }
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    {
+      "blockHash": "0xb14e8716f732186f2c99bb7a215a7cb1ec40e91e8d83739bfb593ed4b9047aa1",
+      "blockNumber": "0x85ef20d",
+      "contractAddress": null,
+      "cumulativeGasUsed": "0x23b6e",
+      "effectiveGasPrice": "0x5d21dba00",
+      "from": "0x60d690e4d5db4025f4781c6cf3bff8669500823c",
+      "gasUsed": "0x23b6e",
+      "logs": [
+        ...
+      ],
+      "logsBloom": "0x00000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000220000000400000000000000000000000000000000000002000000000010001000000000040000000000000000000000000000000000000000000000000000400000080000000100000000000000000000000000000000000000000000480000000000000000000000010000000001000000000000000000000000000000000000000000009000000000000000000000000000000000000000008000000000000000004000000000004000000000000000000000000000000000000000000000000000000000000000200",
+      "status": "0x1",
+      "to": "0x27e1255f2a0ea596992158a0bc838f43be34b99d",
+      "transactionHash": "0xafd15213b06144a85dd02adf88c32efb3d395e784f153c213a40b7ea25de1942",
+      "transactionIndex": "0x0",
+      "type": "0x0"
+    }
+  ]
 }
 ```
 

--- a/docs/dapp/json-rpc/api-references/klay/misc.md
+++ b/docs/dapp/json-rpc/api-references/klay/misc.md
@@ -160,3 +160,44 @@ curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay
   }
 }
 ```
+
+## klay_createAccessList <a id="klay_createaccesslist"></a>
+
+This method creates an `accessList` based on a given `Transaction`.
+The `accessList` contains all storage slots and addresses read and written by the transaction, except for the sender account and the precompiles.
+This method uses the same transaction call object and `blockNumberOrTag` object as [`klay_call`](./transaction.md#klay_call).
+An accessList can be used to unstuck contracts that became inaccessible due to gas cost increases.
+Adding an `accessList` to your transaction does not necessary result in lower gas usage compared to a transaction without an access list.
+
+**Parameters**
+
+| Name             | Type                | Description                                                                                              |
+|------------------|---------------------|----------------------------------------------------------------------------------------------------------|
+| callObject       | Object              | The transaction call object. Refer to [`klay_call`](./transaction.md#klay_call) for the object's properties. |
+| blockNumberOrTag | QUANTITY &#124; TAG | Integer or hexadecimal block number, or the string `"earliest"`, `"latest"` or `"pending"` as in [default block parameter](./block.md#the-default-block-parameter). The block number is mandatory and defines the context (state) against which the specified transaction should be executed. |
+
+**Return Value**
+
+| Type      | Description                                                              |
+|-----------|--------------------------------------------------------------------------|
+| Object    | Returns list of addresses and storage keys used by the transaction, plus the gas consumed when the access list is added. |
+
+**Example**
+
+```shell
+// Request
+curl -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"klay_createAccessList", "params": [{"from": "0x8cd02c6cbd8375b39b06577f8d50c51d86e8d5cd", "data": "0x608060806080608155"}, "latest"], "id":1}' http://localhost:8551
+
+// Result
+{
+  "jsonrpc": "2.0",
+  "id":1,
+  "result": {
+    "accessList": [{
+      "address": "0xa02457e5dfd32bda5fc7e1f1b008aa5979568150",
+      "storageKeys": ["0x0000000000000000000000000000000000000000000000000000000000000081"]
+    }],
+    "gasUsed": "0x128ee"
+  }
+}
+```


### PR DESCRIPTION
## Proposed changes

- This PR updates the API changes in v1.12.0 release, including:
   - Add `admin_nodeConfig` (klaytn/klaytn#1996)
   - Add `{eth, klay}_createAccessList` (klaytn/klaytn#2027)
   - Add `eth_getBlockReceipts` and update `{eth, klay}_getBlockReceipts` to accept block numbers too (klaytn/klaytn#2019)
   - Update `debug_setHead` content (remove warning saying this API is not implemented, and update parameter description)
   - Update `eth_maxPriorityFeePerGas` that it returns 0 after Magma hardfork (klaytn/klaytn#2008)

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [x] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn-docs/blob/master/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn-docs)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues


## Further comments

None