### PR TITLE
adding reexec option at tracing options

### DIFF
--- a/docs/references/json-rpc/debug/tracing.md
+++ b/docs/references/json-rpc/debug/tracing.md
@@ -486,6 +486,7 @@ the options for this specific call. The possible options are:
 - `disableStack`: `BOOL`. Setting this to true will disable stack capture (default = false).
 - `timeout`: `STRING`. Overrides the default timeout of 5 seconds for JavaScript-based tracing calls. Valid values are described [here](https://golang.org/pkg/time/#ParseDuration).
 - `tracer`: `STRING`. Setting this will enable JavaScript-based transaction tracing, described in the [next section](#javascript-based-tracing). If set, the previous four arguments will be ignored. The predefined tracers can also be used as the following table.
+- `reexec`: `INT`. Overrides the default reexec value (default = 128). Reexec value is the maximum number of blocks to reprocess trying to obtain the desired state.
 
 Tracer Name | Description
 -- | --


### PR DESCRIPTION
## Proposed changes

- `reexec` option was missing in tracing options. This PR adds it.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn-docs/blob/master/CONTRIBUTING.md)
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn-docs)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large content contribution, kick off the discussion by explaining why you would suggest the content contribution, etc...