### PR TITLE
Update link to Orakl Network documentation

### DIFF
--- a/docs/build/tools/oracles/oracles.md
+++ b/docs/build/tools/oracles/oracles.md
@@ -6,7 +6,7 @@ The need for blockchains to access and connect to external data sources, legacy 
 
 The following providers have integrated with Klaytn to deliver decentralized oracle services:
 
-* [Orakl Network](https://docs.orakl.network/docs/developers-guide/readme)
+* [Orakl Network](https://docs.orakl.network)
 * [Witnet](https://docs.witnet.io/)
 * [SupraOracles](https://supraoracles.com/docs/overview)
 * [KlayOracle](https://klayoracle.gitbook.io/v1.0.0/)

--- a/i18n/ko/docusaurus-plugin-content-docs/current/build/tools/oracles/oracles.md
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/build/tools/oracles/oracles.md
@@ -6,7 +6,7 @@
 
 다음 공급자들은 클레이튼과 통합하여 탈중앙화된 오라클 서비스를 제공하고 있습니다:
 
-* [Orakl Network](https://docs.orakl.network/docs/developers-guide/readme)
+* [Orakl Network](https://docs.orakl.network)
 * [Witnet](https://docs.witnet.io/)
 * [SupraOracles](https://supraoracles.com/docs/overview)
 * [KlayOracle](https://klayoracle.gitbook.io/v1.0.0/)

--- a/i18n/vi/docusaurus-plugin-content-docs/current/build/tools/oracles/oracles.md
+++ b/i18n/vi/docusaurus-plugin-content-docs/current/build/tools/oracles/oracles.md
@@ -6,7 +6,7 @@ Như cầu về chuỗi khối để truy cập và kết nối với các ngu�
 
 Các nhà cung cấp sau đây đã tích hợp với Klaytn để cung cấp dịch vụ oracle phi tập trung:
 
-* [Hệ Thống Orakl](https://docs.orakl.network/docs/developers-guide/readme)
+* [Orakl Network](https://docs.orakl.network)
 * [Witnet](https://docs.witnet.io/)
 * [SupraOracles](https://supraoracles.com/docs/overview)
 * [KlayOracle](https://klayoracle.gitbook.io/v1.0.0/)


### PR DESCRIPTION
## Proposed changes

The link to Orakl Network documentation on the main Oracles page has been updated.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Minor Issues and Typos
- [ ] Major Content Contribution
- [ ] Others

## Checklist

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn-docs/blob/master/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn-docs)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules