### PR TITLE
Remove gini coefficient part from reward description

### DIFF
--- a/docs/learn/token-economy.md
+++ b/docs/learn/token-economy.md
@@ -26,10 +26,6 @@ For every block, a Committee composed of randomly selected Council members is fo
 
 As long as the minimum 5 million KLAY staking requirement is met, Klaytn Governance Council members can freely stake or unstake his or her own KLAY. Staking information is updated every 86,400 blocks, and newly staked KLAY comes info effect two update cycles later from when the staking is completed. Withdrawing staked KLAY requires one week of delay to prevent malicious members from immediately exiting.
 
-To prevent monopolized claiming of Klaytn Governance Council Reward by small groups of highly invested Council members, Gini coefficient may be used to adjust the effective amount of staked KLAY. The application formula is as follows, where G stands for gini coefficient of Governance Council's KLAY staking distribution:
-
-* _Adjusted staking amount = \(Council member's staking amount\)^\(1/1+G\)_
-
 
 ### Penalty for Misbehaving Council Members <a id="penalty-for-misbehaving-council-members"></a>
 


### PR DESCRIPTION
## Proposed changes

Remove gini coefficient part from the reward description because the mechanism is removed after https://kips.klaytn.foundation/KIPs/kip-82 

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Minor Issues and Typos
- [ ] Major Content Contribution
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to reach out. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/klaytn/klaytn-docs/blob/master/CONTRIBUTING.md)
- [x] I have signed the [CLA](https://cla-assistant.io/klaytn/klaytn-docs)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
